### PR TITLE
Release v1.1.0: migrate from cookie auth to API key auth

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -32,17 +32,22 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Create ZIP with WXT
-        run: npm run zip
+      - name: Type-check
+        run: npm run compile
+
+      - name: Build ZIPs (Chrome + Firefox)
+        run: |
+          npm run zip
+          npm run zip:firefox
 
       - name: List output files
         run: ls -la .output/
 
-      - name: Upload build artifact
+      - name: Upload build artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: twenty-crm-extension-chrome
-          path: .output/*-chrome.zip
+          name: twenty-crm-extension
+          path: .output/*.zip
 
       - name: Create Release
         if: startsWith(github.ref, 'refs/tags/v') || github.event.inputs.version != ''
@@ -51,27 +56,24 @@ jobs:
           tag_name: ${{ github.event.inputs.version || github.ref_name }}
           name: Twenty CRM LinkedIn Extension ${{ github.event.inputs.version || github.ref_name }}
           body: |
-            ## 📥 Download & Install
+            ## Installation
 
-            1. Download the `.zip` file below
-            2. **Unzip** the file - creates a folder with `manifest.json` inside
-            3. Open Chrome → `chrome://extensions`
-            4. Enable **Developer mode** (top right)
-            5. Click **Load unpacked** → select the folder containing `manifest.json`
-            6. Click the extension icon and enter your Twenty CRM URL
+            1. Download the Chrome (`*-chrome.zip`) or Firefox (`*-firefox.zip`) build below.
+            2. Unzip it. The folder should contain `manifest.json` at its root.
+            3. Chrome: open `chrome://extensions`, enable Developer mode, click Load unpacked, and select the unzipped folder.
+            4. Click the extension icon and enter your Twenty URL and API key (Settings -> Developers in Twenty).
 
-            > ⚠️ Make sure you select the folder that has `manifest.json` directly inside, not a parent folder.
+            ## Features
 
-            ## ✨ Features
-
-            - Capture LinkedIn profiles & companies to Twenty CRM
-            - Auto-create companies when adding contacts
-            - Upload profile photos to Twenty storage
-            - Detect duplicates by LinkedIn URL or name
+            - Capture LinkedIn profiles and companies into Twenty CRM
+            - Auto-create the contact's current company when needed
+            - Duplicate detection by LinkedIn URL or name
             - Update existing records from LinkedIn
-            - Multi-language support (EN, FR, DE, ES)
+            - Search and link a profile to an existing record
 
-            See [CHANGELOG.md](https://github.com/${{ github.repository }}/blob/main/CHANGELOG.md) for full details.
-          files: .output/*-chrome.zip
+            See [CHANGELOG.md](https://github.com/${{ github.repository }}/blob/main/CHANGELOG.md) for details.
+          files: |
+            .output/*-chrome.zip
+            .output/*-firefox.zip
           draft: false
           prerelease: false

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,15 @@ stats-*.json
 .wxt
 web-ext.config.ts
 
+# Environment / secrets
+.env
+.env.*
+!.env.example
+*.local
+
+# Packaged builds
+*.zip
+
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,38 @@
 
 All notable changes to Twenty CRM LinkedIn Capture Extension.
 
+## [1.1.0] - 2026-06-25
+
+### Changed
+
+- Authentication now uses a Twenty API key entered in the popup, instead of the
+  session cookie. The key is stored in the browser's local extension storage.
+- Requests send credentials so deployments behind an authenticating reverse
+  proxy pass the gateway; this is a no-op for instances without one.
+- Connection test now probes the `people` query rather than a removed root field.
+
+### Added
+
+- Schema-tolerant writes: input fields the target Twenty schema does not accept
+  are dropped automatically, and the location field is resolved by introspection
+  (scalar `city`/`location` or an ADDRESS composite, with country detection).
+- Resilient LinkedIn scraping using structural anchors (page heading, contact
+  row, company entity, labelled photo) that tolerate UI/class changes.
+
+### Fixed
+
+- Capture and update against current Twenty schema and the redesigned LinkedIn DOM.
+- Search panel no longer flickers while typing.
+
+### Removed
+
+- Profile photo upload via the GraphQL multipart mutation, which is no longer
+  available; the photo URL is captured instead.
+
+### Maintenance
+
+- Updated dependencies (WXT, Vue, TypeScript) and refreshed documentation.
+
 ## [1.0.0] - 2024-12-17
 
 ### ✨ Features

--- a/README.md
+++ b/README.md
@@ -1,168 +1,104 @@
 # Twenty CRM - LinkedIn Capture Extension
 
-A Chrome extension to capture LinkedIn profiles and companies directly into your self-hosted [Twenty CRM](https://twenty.com).
+A browser extension that captures LinkedIn profiles and companies into a self-hosted [Twenty CRM](https://twenty.com) instance. Built with [WXT](https://wxt.dev/) and Vue 3.
 
----
+## Features
 
-## 📥 Download & Install
+| Feature | Description |
+| --- | --- |
+| LinkedIn capture | One-click capture of LinkedIn profiles and companies into Twenty |
+| Company auto-create | Creates the contact's current company if it does not already exist |
+| Duplicate detection | Checks for an existing record by LinkedIn URL or name before creating |
+| Update existing | Refreshes an existing CRM record with the latest LinkedIn data |
+| Manual linking | Searches the CRM and links a LinkedIn profile to an existing record |
+| Resilient scraping | Extracts data using structural anchors that tolerate LinkedIn UI changes |
+| Schema-tolerant writes | Adapts to differences in the target Twenty schema across versions |
 
-### Quick Install (Recommended)
+## Installation
 
-1. **[⬇️ Download Latest Release](../../releases/latest)**
-2. Download the `twenty-crm-linkedin-extension-*-chrome.zip` file
-3. **Unzip** the file - you should see `manifest.json` and other files directly inside
-4. Open Chrome → `chrome://extensions`
-5. Enable **Developer mode** (toggle top right)
-6. Click **Load unpacked** → select the **unzipped folder** (the one containing `manifest.json`)
-7. Click the extension icon and enter your Twenty CRM URL
+1. Download the latest `*-chrome.zip` from the [Releases page](../../releases/latest).
+2. Unzip it. The folder should contain `manifest.json` at its root.
+3. Open `chrome://extensions` and enable **Developer mode** (top right).
+4. Click **Load unpacked** and select the unzipped folder.
 
-> **Note**: You must be logged into your Twenty CRM in the same browser for the extension to work.
->
-> **Tip**: After unzipping, verify the folder contains `manifest.json` at the root level, not inside a subfolder.
+For Firefox, load the `*-firefox.zip` build via `about:debugging`.
 
----
+## Configuration
 
-## ✨ Features
+1. In Twenty, open **Settings → Developers** and create an API key.
+2. Click the extension icon and enter:
+   - **Twenty URL** — the base URL of your instance (for example, `https://crm.example.com`).
+   - **API key** — the key created above.
+3. Click **Save**, then **Test Connection**. The status should read **Connected**.
 
-| Feature                    | Description                                                |
-| -------------------------- | ---------------------------------------------------------- |
-| 🔗 **LinkedIn Capture**    | One-click capture of LinkedIn profiles to your CRM         |
-| 🏢 **Company Auto-Create** | Automatically creates company records when adding contacts |
-| 📸 **Photo Upload**        | Uploads LinkedIn profile photos directly to Twenty storage |
-| 🔍 **Duplicate Detection** | Checks if contact/company exists by LinkedIn URL or name   |
-| 🔄 **Update Existing**     | Refresh CRM records with latest LinkedIn data              |
-| 🔎 **Manual Linking**      | Search and link LinkedIn profiles to existing CRM contacts |
-| 🌍 **Multi-language**      | Extracts company names in EN, FR, DE, ES headlines         |
+The API key is stored only in the browser's local extension storage and is sent
+as a bearer token with each request.
 
----
+If your Twenty instance sits behind an authenticating reverse proxy, keep a
+logged-in browser session to that domain so requests pass the gateway.
 
-## 🚀 Usage
+## Usage
 
-### Capturing a LinkedIn Profile
+### Profiles
 
-1. Visit any LinkedIn profile (`linkedin.com/in/username`)
-2. A button appears in the **bottom-left corner**:
-
-   | Button State       | Meaning                               |
-   | ------------------ | ------------------------------------- |
-   | **Add to Twenty**  | Profile not in CRM - click to add     |
-   | **Open in Twenty** | Profile exists - click to view in CRM |
-
-3. Click `•••` for more options:
-   - **Link to existing contact** - Search and link to existing record
-   - **Update from LinkedIn** - Refresh CRM with current LinkedIn data
-
-### Capturing a Company
-
-Same process - visit any LinkedIn company page (`linkedin.com/company/name`)
-
----
-
-## 📋 Data Captured
-
-### People
-
-- ✅ First name & Last name
-- ✅ Job title / headline
-- ✅ Profile photo (uploaded to Twenty)
-- ✅ Location
-- ✅ LinkedIn URL
-- ✅ Current company (auto-created if needed)
+1. Open any LinkedIn profile (`linkedin.com/in/...`).
+2. A button appears in the bottom-left corner:
+   - **Add to Twenty** — the profile is not yet in the CRM; click to create it.
+   - **Open in Twenty** — the profile already exists; click to view it.
+3. Use the `...` menu for more actions:
+   - **Link to existing contact** — search the CRM and link to an existing record.
+   - **Update from LinkedIn** — refresh the existing record with current data.
 
 ### Companies
 
-- ✅ Company name
-- ✅ LinkedIn URL
-- ✅ Website (when available)
-- ✅ Employee count
-- ✅ Company logo
+The same flow applies on any LinkedIn company page (`linkedin.com/company/...`).
 
----
+## Data captured
 
-## 🛠️ Build from Source
+**People:** first and last name, job title / headline, location, LinkedIn URL,
+current company (created automatically when needed), and profile photo URL.
+
+**Companies:** name, LinkedIn URL, website, and employee count when available.
+
+Optional fields are only sent when present, and the extension adapts to the
+fields the target Twenty schema actually exposes.
+
+## Build from source
 
 ```bash
-# Clone the repository
-git clone https://github.com/YOUR_USERNAME/twenty-crm-extension.git
+git clone https://github.com/pi3ch/twenty-crm-extension.git
 cd twenty-crm-extension
-
-# Install dependencies
 npm install
 
-# Development with hot reload
-npm run dev
-
-# Build for production
-npm run build
-
-# Create distributable ZIP
-npm run zip
+npm run dev      # development build with hot reload
+npm run build    # production build (output in .output/chrome-mv3/)
+npm run zip      # packaged distributable
 ```
 
-The built extension is in `.output/chrome-mv3/`
+## Troubleshooting
 
----
+| Issue | Suggestion |
+| --- | --- |
+| Connection test fails | Verify the Twenty URL and API key, and that the API key is active |
+| Button not appearing | Reload the LinkedIn page and confirm the extension is enabled |
+| A field is not captured | Open the page console; the scraper logs the values it extracts |
 
-## 🏷️ Creating a Release
+Debug logs:
 
-**Option 1: Git Tag**
+- **Page console** (F12): content-script and scraping logs.
+- **Service worker**: `chrome://extensions` → the extension's "Service worker" link, for API request logs.
 
-```bash
-git tag v1.0.0
-git push origin v1.0.0
-```
+## Tech stack
 
-**Option 2: Manual**
-
-1. Go to GitHub → Actions → "Build and Release Extension"
-2. Click "Run workflow"
-3. Enter version (e.g., `v1.0.0`)
-
-GitHub Actions will automatically build and create a release with the ZIP file.
-
----
-
-## 🔧 Requirements
-
-- Chrome or Chromium-based browser
-- Self-hosted Twenty CRM instance
-- Logged into Twenty CRM in the same browser
-
----
-
-## ❓ Troubleshooting
-
-| Issue                     | Solution                                                             |
-| ------------------------- | -------------------------------------------------------------------- |
-| "Failed to save settings" | Check your Twenty URL is correct and you're logged in                |
-| Button not appearing      | Refresh the LinkedIn page, check extension is enabled                |
-| Profile photo not showing | Check Twenty's file storage is configured                            |
-| Company not created       | Headline may not have recognizable pattern (`at/chez/@/bei` Company) |
-
-### Debug Logs
-
-- **Page console** (F12): Shows scraping logs
-- **Service Worker**: Go to `chrome://extensions` → click "Service Worker" under the extension
-
----
-
-## 📚 Tech Stack
-
-- [WXT](https://wxt.dev/) - Web Extension Framework
-- [Vue 3](https://vuejs.org/) - Popup UI
+- [WXT](https://wxt.dev/) — web extension framework
+- [Vue 3](https://vuejs.org/) — popup UI
 - TypeScript
 - Twenty CRM GraphQL API
 
----
+## Credits
 
-## 📄 License
+This project is a fork of [JhumanJ/twenty-crm-extension](https://github.com/JhumanJ/twenty-crm-extension). Thanks to the original author for the foundation this builds on.
+
+## License
 
 MIT
-
----
-
-## 🔗 Links
-
-- [Twenty CRM](https://twenty.com)
-- [WXT Documentation](https://wxt.dev)
-- [Report an Issue](../../issues)

--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -1,4 +1,4 @@
-import { TwentyApiClient, extractTokenFromCookie } from '../utils/twenty-api';
+import { TwentyApiClient } from '../utils/twenty-api';
 import { getSettings, saveSettings, addToRecentCaptures, getRecentCaptures } from '../utils/storage';
 import type { ExtensionMessage, ExtensionResponse, LinkedInProfileData, LinkedInCompanyData } from '../types';
 
@@ -14,70 +14,18 @@ async function getApiClient(): Promise<TwentyApiClient> {
     throw new Error('Twenty URL not configured');
   }
   
+  if (!settings.apiKey) {
+    throw new Error('No API key configured. Add a Twenty API key in the extension settings.');
+  }
+
   // Create new client if URL changed
   if (cachedTwentyUrl !== settings.twentyUrl || !apiClient) {
     apiClient = new TwentyApiClient(settings.twentyUrl);
     cachedTwentyUrl = settings.twentyUrl;
   }
-  
-  // Get fresh token from cookie
-  const token = await getAuthToken(settings.twentyUrl);
-  if (!token) {
-    throw new Error('No authentication token found. Please log in to Twenty CRM.');
-  }
-  
-  apiClient.setToken(token);
+
+  apiClient.setToken(settings.apiKey);
   return apiClient;
-}
-
-// Extract domain from URL for cookie access
-function extractDomain(url: string): string {
-  try {
-    const urlObj = new URL(url);
-    return urlObj.hostname;
-  } catch {
-    return url;
-  }
-}
-
-// Get auth token from Twenty's cookie
-async function getAuthToken(twentyUrl: string): Promise<string | null> {
-  try {
-    // Try to get the tokenPair cookie from Twenty domain
-    const cookie = await browser.cookies.get({
-      url: twentyUrl,
-      name: 'tokenPair',
-    });
-    
-    console.log('Cookie lookup for', twentyUrl, ':', cookie ? 'found' : 'not found');
-    
-    if (cookie?.value) {
-      const decodedValue = decodeURIComponent(cookie.value);
-      return extractTokenFromCookie(decodedValue);
-    }
-    
-    // Also try without www
-    const altUrl = twentyUrl.includes('://www.') 
-      ? twentyUrl.replace('://www.', '://') 
-      : twentyUrl.replace('://', '://www.');
-    
-    const altCookie = await browser.cookies.get({
-      url: altUrl,
-      name: 'tokenPair',
-    });
-    
-    console.log('Alt cookie lookup for', altUrl, ':', altCookie ? 'found' : 'not found');
-    
-    if (altCookie?.value) {
-      const decodedValue = decodeURIComponent(altCookie.value);
-      return extractTokenFromCookie(decodedValue);
-    }
-    
-    return null;
-  } catch (error) {
-    console.error('Error getting auth token:', error);
-    return null;
-  }
 }
 
 // Check if a person already exists (by LinkedIn URL or name)
@@ -228,8 +176,7 @@ async function handleMessage(message: ExtensionMessage): Promise<ExtensionRespon
         if (!settings.twentyUrl) {
           return { success: false, error: 'Twenty URL not configured' };
         }
-        const token = await getAuthToken(settings.twentyUrl);
-        return { success: !!token, data: { hasToken: !!token } };
+        return { success: !!settings.apiKey, data: { hasToken: !!settings.apiKey } };
       }
       
       case 'CHECK_DUPLICATE': {
@@ -250,21 +197,21 @@ async function handleMessage(message: ExtensionMessage): Promise<ExtensionRespon
       
       case 'GET_SETTINGS': {
         const settings = await getSettings();
-        const hasToken = settings.twentyUrl 
-          ? !!(await getAuthToken(settings.twentyUrl)) 
-          : false;
-        return { 
-          success: true, 
-          data: { ...settings, hasToken } 
+        const hasToken = !!settings.apiKey;
+        // Never expose the stored API key back to the UI; just report whether one is set
+        const { apiKey, ...safeSettings } = settings;
+        return {
+          success: true,
+          data: { ...safeSettings, hasToken }
         };
       }
-      
+
       case 'SAVE_SETTINGS': {
-        const newSettings = message.payload as { twentyUrl?: string };
-        console.log('Saving settings:', newSettings);
+        const newSettings = message.payload as { twentyUrl?: string; apiKey?: string };
+        console.log('Saving settings:', { ...newSettings, apiKey: newSettings.apiKey ? '***' : undefined });
         await saveSettings(newSettings);
-        // Clear cached client when URL changes
-        if (newSettings.twentyUrl) {
+        // Clear cached client when URL or key changes
+        if (newSettings.twentyUrl !== undefined || newSettings.apiKey !== undefined) {
           apiClient = null;
           cachedTwentyUrl = null;
         }

--- a/entrypoints/content.ts
+++ b/entrypoints/content.ts
@@ -346,10 +346,13 @@ export default defineContentScript({
     let searchResults: SearchResult[] = [];
     let isSearching = false;
     let searchDebounceTimer: ReturnType<typeof setTimeout> | null = null;
-    
+
     // DOM elements
     let container: HTMLDivElement | null = null;
     let styleEl: HTMLStyleElement | null = null;
+    // Live reference to the search results list, so search updates can patch it
+    // in place instead of rebuilding (and re-animating) the whole panel.
+    let searchResultsEl: HTMLDivElement | null = null;
     
     // Initialize
     function init() {
@@ -495,24 +498,61 @@ export default defineContentScript({
       }
     }
     
+    // Escape untrusted text (CRM/LinkedIn data) before inserting via innerHTML
+    function escapeHtml(s: string): string {
+      const div = document.createElement('div');
+      div.textContent = s;
+      return div.innerHTML;
+    }
+
+    // Patch only the results list. Rebuilding the whole panel on every keystroke
+    // replays the entrance animation (visible flicker) and steals input focus.
+    function populateSearchResults() {
+      const resultsDiv = searchResultsEl;
+      if (!resultsDiv) return;
+
+      // Only show the loading state on the first query (nothing to show yet).
+      // While refining a search, keep the current results visible to avoid a
+      // flash between "Searching..." and the new list on every keystroke.
+      if (isSearching && searchResults.length === 0) {
+        resultsDiv.innerHTML = '<div class="twenty-search-loading">Searching...</div>';
+      } else if (!isSearching && searchQuery && searchResults.length === 0) {
+        resultsDiv.innerHTML = '<div class="twenty-search-empty">No contacts found</div>';
+      } else if (searchResults.length > 0) {
+        resultsDiv.innerHTML = '';
+        searchResults.forEach((result) => {
+          const item = document.createElement('div');
+          item.className = 'twenty-search-result';
+          item.innerHTML = `
+            <div class="twenty-search-result-name">${escapeHtml(result.name)}</div>
+            ${result.subtitle ? `<div class="twenty-search-result-sub">${escapeHtml(result.subtitle)}</div>` : ''}
+          `;
+          item.addEventListener('click', () => linkToRecord(result));
+          resultsDiv.appendChild(item);
+        });
+      } else {
+        resultsDiv.innerHTML = '<div class="twenty-search-empty">Type to search...</div>';
+      }
+    }
+
     // Search CRM for contacts
     async function searchCRM(query: string) {
       if (!query.trim()) {
         searchResults = [];
-        render();
+        populateSearchResults();
         return;
       }
-      
+
       isSearching = true;
-      render();
-      
+      populateSearchResults();
+
       try {
         const pageType = getLinkedInPageType(window.location.href);
         const response = await browser.runtime.sendMessage({
           type: 'SEARCH_RECORDS',
           payload: { query, type: pageType },
         }) as ExtensionResponse<SearchResult[]>;
-        
+
         if (response.success && response.data) {
           searchResults = response.data;
         } else {
@@ -522,9 +562,9 @@ export default defineContentScript({
         console.error('Error searching:', error);
         searchResults = [];
       }
-      
+
       isSearching = false;
-      render();
+      populateSearchResults();
     }
     
     // Link to existing record and update it
@@ -716,7 +756,10 @@ export default defineContentScript({
     // Render function
     function render() {
       if (!container) return;
-      
+
+      // Any previous results node is about to be discarded; drop the stale ref.
+      searchResultsEl = null;
+
       const wrapper = document.createElement('div');
       wrapper.className = 'twenty-capture-container';
       
@@ -803,32 +846,15 @@ export default defineContentScript({
         inputWrap.appendChild(input);
         panel.appendChild(inputWrap);
         
-        // Results
+        // Results — built once here, then patched in place by populateSearchResults()
         const resultsDiv = document.createElement('div');
         resultsDiv.className = 'twenty-search-results';
-        
-        if (isSearching) {
-          resultsDiv.innerHTML = '<div class="twenty-search-loading">Searching...</div>';
-        } else if (searchQuery && searchResults.length === 0) {
-          resultsDiv.innerHTML = '<div class="twenty-search-empty">No contacts found</div>';
-        } else if (searchResults.length > 0) {
-          searchResults.forEach((result) => {
-            const item = document.createElement('div');
-            item.className = 'twenty-search-result';
-            item.innerHTML = `
-              <div class="twenty-search-result-name">${result.name}</div>
-              ${result.subtitle ? `<div class="twenty-search-result-sub">${result.subtitle}</div>` : ''}
-            `;
-            item.addEventListener('click', () => linkToRecord(result));
-            resultsDiv.appendChild(item);
-          });
-        } else {
-          resultsDiv.innerHTML = '<div class="twenty-search-empty">Type to search...</div>';
-        }
-        
         panel.appendChild(resultsDiv);
+        searchResultsEl = resultsDiv;
+        populateSearchResults();
+
         wrapper.appendChild(panel);
-        
+
         // Focus input after render
         setTimeout(() => input.focus(), 50);
       }

--- a/entrypoints/popup/App.vue
+++ b/entrypoints/popup/App.vue
@@ -4,6 +4,7 @@ import type { ExtensionResponse } from '../../types';
 
 // State
 const twentyUrl = ref('');
+const apiKey = ref('');
 const hasToken = ref(false);
 const isConnected = ref(false);
 const isLoading = ref(true);
@@ -31,7 +32,7 @@ const connectionStatus = computed(() => {
 const statusText = computed(() => {
   switch (connectionStatus.value) {
     case 'not-configured': return 'Not configured';
-    case 'no-session': return 'Not logged in';
+    case 'no-session': return 'No API key';
     case 'connected': return 'Connected';
     case 'disconnected': return 'Connection failed';
     default: return 'Unknown';
@@ -94,7 +95,7 @@ async function saveSettings() {
     error.value = 'Please enter your Twenty URL';
     return;
   }
-  
+
   // Normalize URL
   let url = twentyUrl.value.trim();
   if (!url.startsWith('http://') && !url.startsWith('https://')) {
@@ -102,19 +103,27 @@ async function saveSettings() {
   }
   url = url.replace(/\/$/, ''); // Remove trailing slash
   twentyUrl.value = url;
-  
+
   isSaving.value = true;
   error.value = null;
   success.value = null;
-  
+
   try {
+    // Only send the API key when the user actually entered one, so re-saving
+    // the URL doesn't wipe a previously stored key.
+    const payload: { twentyUrl: string; apiKey?: string } = { twentyUrl: url };
+    if (apiKey.value.trim()) {
+      payload.apiKey = apiKey.value.trim();
+    }
+
     const response = await browser.runtime.sendMessage({
       type: 'SAVE_SETTINGS',
-      payload: { twentyUrl: url },
+      payload,
     }) as ExtensionResponse;
-    
+
     if (response.success) {
       success.value = 'Settings saved!';
+      apiKey.value = ''; // clear the input; the key is stored, never read back
       // Reload to check token
       await loadSettings();
     } else {
@@ -221,6 +230,20 @@ function formatDate(timestamp: number): string {
           <p class="hint">Your self-hosted Twenty instance URL</p>
         </div>
 
+        <div class="form-group">
+          <label class="label" for="apiKey">API Key</label>
+          <input
+            id="apiKey"
+            v-model="apiKey"
+            type="password"
+            class="input"
+            autocomplete="off"
+            :placeholder="hasToken ? '•••••••• (saved — type to replace)' : 'Paste your Twenty API key'"
+            @keyup.enter="saveSettings"
+          />
+          <p class="hint">Twenty → Settings → Developers → API keys</p>
+        </div>
+
         <div class="button-group">
           <button 
             class="btn btn--primary" 
@@ -247,10 +270,11 @@ function formatDate(timestamp: number): string {
         </div>
       </section>
 
-      <!-- Login Prompt -->
+      <!-- API key prompt -->
       <section v-if="isConfigured && !hasToken" class="section section--warning">
         <p class="warning-text">
-          Please log in to your Twenty instance to use the extension.
+          Add a Twenty API key above to use the extension. Generate one in
+          Twenty → Settings → Developers → API keys.
         </p>
         <button class="btn btn--primary" @click="openTwenty">
           Open Twenty →
@@ -292,7 +316,7 @@ function formatDate(timestamp: number): string {
         <h2 class="section__title">How to use</h2>
         <ol class="instructions">
           <li>Enter your Twenty CRM URL above</li>
-          <li>Log in to Twenty in your browser</li>
+          <li>Paste a Twenty API key (Settings → Developers)</li>
           <li>Visit any LinkedIn profile or company page</li>
           <li>Click the floating button to capture</li>
         </ol>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,21 +1,21 @@
 {
-  "name": "wxt-vue-starter",
-  "version": "0.0.0",
+  "name": "twenty-crm-linkedin-extension",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "wxt-vue-starter",
-      "version": "0.0.0",
+      "name": "twenty-crm-linkedin-extension",
+      "version": "1.0.0",
       "hasInstallScript": true,
       "dependencies": {
-        "vue": "^3.5.25"
+        "vue": "^3.5.38"
       },
       "devDependencies": {
         "@wxt-dev/module-vue": "^1.0.3",
-        "typescript": "^5.9.3",
-        "vue-tsc": "^3.1.8",
-        "wxt": "^0.20.6"
+        "typescript": "^6.0.3",
+        "vue-tsc": "^3.3.5",
+        "wxt": "^0.20.27"
       }
     },
     "node_modules/@1natsu/wait-element": {
@@ -149,30 +149,30 @@
       "license": "MIT"
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.5.tgz",
-      "integrity": "sha512-KKBU1VGYR7ORr3At5HAtUQ+TV3SzRCXmA/8OdDZiLDBIZxVyzXuztPjfLd3BV1PRAQGCMWWSHYhL0F8d5uHBDQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.28.5"
+        "@babel/types": "^7.29.7"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -192,13 +192,13 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.5.tgz",
-      "integrity": "sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.28.5"
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -688,29 +688,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/@isaacs/balanced-match": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@isaacs/balanced-match/-/balanced-match-4.0.1.tgz",
-      "integrity": "sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
-    "node_modules/@isaacs/brace-expansion": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@isaacs/brace-expansion/-/brace-expansion-5.0.0.tgz",
-      "integrity": "sha512-ZT55BDLV0yv0RBm2czMiZ+SqCGO7AvmOM3G/w2xhVPH+te0aKgFjmBvGlL1dH+ql2tgGO3MVrbb3jCKyvpgnxA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@isaacs/balanced-match": "^4.0.1"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -758,44 +735,6 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
-      }
-    },
-    "node_modules/@nodelib/fs.scandir": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
-      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@nodelib/fs.stat": "2.0.5",
-        "run-parallel": "^1.1.9"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/@nodelib/fs.stat": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
-      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/@nodelib/fs.walk": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
-      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@nodelib/fs.scandir": "2.1.5",
-        "fastq": "^1.6.0"
-      },
-      "engines": {
-        "node": ">= 8"
       }
     },
     "node_modules/@pnpm/config.env-replace": {
@@ -1224,156 +1163,160 @@
       }
     },
     "node_modules/@volar/language-core": {
-      "version": "2.4.26",
-      "resolved": "https://registry.npmjs.org/@volar/language-core/-/language-core-2.4.26.tgz",
-      "integrity": "sha512-hH0SMitMxnB43OZpyF1IFPS9bgb2I3bpCh76m2WEK7BE0A0EzpYsRp0CCH2xNKshr7kacU5TQBLYn4zj7CG60A==",
+      "version": "2.4.28",
+      "resolved": "https://registry.npmjs.org/@volar/language-core/-/language-core-2.4.28.tgz",
+      "integrity": "sha512-w4qhIJ8ZSitgLAkVay6AbcnC7gP3glYM3fYwKV3srj8m494E3xtrCv6E+bWviiK/8hs6e6t1ij1s2Endql7vzQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@volar/source-map": "2.4.26"
+        "@volar/source-map": "2.4.28"
       }
     },
     "node_modules/@volar/source-map": {
-      "version": "2.4.26",
-      "resolved": "https://registry.npmjs.org/@volar/source-map/-/source-map-2.4.26.tgz",
-      "integrity": "sha512-JJw0Tt/kSFsIRmgTQF4JSt81AUSI1aEye5Zl65EeZ8H35JHnTvFGmpDOBn5iOxd48fyGE+ZvZBp5FcgAy/1Qhw==",
+      "version": "2.4.28",
+      "resolved": "https://registry.npmjs.org/@volar/source-map/-/source-map-2.4.28.tgz",
+      "integrity": "sha512-yX2BDBqJkRXfKw8my8VarTyjv48QwxdJtvRgUpNE5erCsgEUdI2DsLbpa+rOQVAJYshY99szEcRDmyHbF10ggQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@volar/typescript": {
-      "version": "2.4.26",
-      "resolved": "https://registry.npmjs.org/@volar/typescript/-/typescript-2.4.26.tgz",
-      "integrity": "sha512-N87ecLD48Sp6zV9zID/5yuS1+5foj0DfuYGdQ6KHj/IbKvyKv1zNX6VCmnKYwtmHadEO6mFc2EKISiu3RDPAvA==",
+      "version": "2.4.28",
+      "resolved": "https://registry.npmjs.org/@volar/typescript/-/typescript-2.4.28.tgz",
+      "integrity": "sha512-Ja6yvWrbis2QtN4ClAKreeUZPVYMARDYZl9LMEv1iQ1QdepB6wn0jTRxA9MftYmYa4DQ4k/DaSZpFPUfxl8giw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@volar/language-core": "2.4.26",
+        "@volar/language-core": "2.4.28",
         "path-browserify": "^1.0.1",
         "vscode-uri": "^3.0.8"
       }
     },
     "node_modules/@vue/compiler-core": {
-      "version": "3.5.25",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.25.tgz",
-      "integrity": "sha512-vay5/oQJdsNHmliWoZfHPoVZZRmnSWhug0BYT34njkYTPqClh3DNWLkZNJBVSjsNMrg0CCrBfoKkjZQPM/QVUw==",
+      "version": "3.5.38",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.38.tgz",
+      "integrity": "sha512-s99aGxWYig9ErHbct27KXEGhrBYlRI6c4MwAgXErOAbX9xiW37/uMa+XUDO69zLz83dng8UUZ70CTOJrLrYrEQ==",
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.28.5",
-        "@vue/shared": "3.5.25",
-        "entities": "^4.5.0",
+        "@babel/parser": "^7.29.7",
+        "@vue/shared": "3.5.38",
+        "entities": "^7.0.1",
         "estree-walker": "^2.0.2",
         "source-map-js": "^1.2.1"
       }
     },
+    "node_modules/@vue/compiler-core/node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/@vue/compiler-dom": {
-      "version": "3.5.25",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.25.tgz",
-      "integrity": "sha512-4We0OAcMZsKgYoGlMjzYvaoErltdFI2/25wqanuTu+S4gismOTRTBPi4IASOjxWdzIwrYSjnqONfKvuqkXzE2Q==",
+      "version": "3.5.38",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.38.tgz",
+      "integrity": "sha512-JTqp25l8aFfJYF7/KmsXZjAxJz7T+SjmTJLoXVjHtc2BrSgSiW2n9Aem/cWq1OPe68A8JL06B3eVdhlP0H4TVw==",
       "license": "MIT",
       "dependencies": {
-        "@vue/compiler-core": "3.5.25",
-        "@vue/shared": "3.5.25"
+        "@vue/compiler-core": "3.5.38",
+        "@vue/shared": "3.5.38"
       }
     },
     "node_modules/@vue/compiler-sfc": {
-      "version": "3.5.25",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.25.tgz",
-      "integrity": "sha512-PUgKp2rn8fFsI++lF2sO7gwO2d9Yj57Utr5yEsDf3GNaQcowCLKL7sf+LvVFvtJDXUp/03+dC6f2+LCv5aK1ag==",
+      "version": "3.5.38",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.38.tgz",
+      "integrity": "sha512-DuA2GiZawSEW442iw/9+Fkol8hTgb4Ke5KkhmSry65QA7YuyMbIdy8p0XZRMvNwJdgRz307W8g1CSzdvS4nuNg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.28.5",
-        "@vue/compiler-core": "3.5.25",
-        "@vue/compiler-dom": "3.5.25",
-        "@vue/compiler-ssr": "3.5.25",
-        "@vue/shared": "3.5.25",
+        "@babel/parser": "^7.29.7",
+        "@vue/compiler-core": "3.5.38",
+        "@vue/compiler-dom": "3.5.38",
+        "@vue/compiler-ssr": "3.5.38",
+        "@vue/shared": "3.5.38",
         "estree-walker": "^2.0.2",
         "magic-string": "^0.30.21",
-        "postcss": "^8.5.6",
+        "postcss": "^8.5.15",
         "source-map-js": "^1.2.1"
       }
     },
     "node_modules/@vue/compiler-ssr": {
-      "version": "3.5.25",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.25.tgz",
-      "integrity": "sha512-ritPSKLBcParnsKYi+GNtbdbrIE1mtuFEJ4U1sWeuOMlIziK5GtOL85t5RhsNy4uWIXPgk+OUdpnXiTdzn8o3A==",
+      "version": "3.5.38",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.38.tgz",
+      "integrity": "sha512-7s+W5Gc42FGxZMcuwl8H5B29T8BJPMdBT7KHFE+BbAuZ/iTEdTtv7z2XiMjiaUUw4w3ZcCEdHs36RuYJ2VA7bA==",
       "license": "MIT",
       "dependencies": {
-        "@vue/compiler-dom": "3.5.25",
-        "@vue/shared": "3.5.25"
+        "@vue/compiler-dom": "3.5.38",
+        "@vue/shared": "3.5.38"
       }
     },
     "node_modules/@vue/language-core": {
-      "version": "3.1.8",
-      "resolved": "https://registry.npmjs.org/@vue/language-core/-/language-core-3.1.8.tgz",
-      "integrity": "sha512-PfwAW7BLopqaJbneChNL6cUOTL3GL+0l8paYP5shhgY5toBNidWnMXWM+qDwL7MC9+zDtzCF2enT8r6VPu64iw==",
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/@vue/language-core/-/language-core-3.3.5.tgz",
+      "integrity": "sha512-UkKu5nhX89fg4VhlG/FOeI10G3cj/7radKT/cy9BT4Q9qJmJlSTAc/dP63Xqs29aypN4f39xUV6PsLNk/dcD6g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@volar/language-core": "2.4.26",
+        "@volar/language-core": "2.4.28",
         "@vue/compiler-dom": "^3.5.0",
         "@vue/shared": "^3.5.0",
-        "alien-signals": "^3.0.0",
+        "alien-signals": "^3.2.0",
         "muggle-string": "^0.4.1",
         "path-browserify": "^1.0.1",
-        "picomatch": "^4.0.2"
-      },
-      "peerDependencies": {
-        "typescript": "*"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
+        "picomatch": "^4.0.4"
       }
     },
     "node_modules/@vue/reactivity": {
-      "version": "3.5.25",
-      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.25.tgz",
-      "integrity": "sha512-5xfAypCQepv4Jog1U4zn8cZIcbKKFka3AgWHEFQeK65OW+Ys4XybP6z2kKgws4YB43KGpqp5D/K3go2UPPunLA==",
+      "version": "3.5.38",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.38.tgz",
+      "integrity": "sha512-pG6LV/NDNRbKizcUjFFLAfjaL8mcv4DmR9avNcUw2gDHBzZneuS2TWCmp633ynzxz9YYKNeEPK2I8Wraqy2HUQ==",
       "license": "MIT",
       "dependencies": {
-        "@vue/shared": "3.5.25"
+        "@vue/shared": "3.5.38"
       }
     },
     "node_modules/@vue/runtime-core": {
-      "version": "3.5.25",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.25.tgz",
-      "integrity": "sha512-Z751v203YWwYzy460bzsYQISDfPjHTl+6Zzwo/a3CsAf+0ccEjQ8c+0CdX1WsumRTHeywvyUFtW6KvNukT/smA==",
+      "version": "3.5.38",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.38.tgz",
+      "integrity": "sha512-iyW8WVfF1CpCXxncZY5Ei6rSd6oZr5DgEom//fUjRBRl56AXPD+s9ATvukRt77ZFTuYlnVA1bxY+dJB94tWVYw==",
       "license": "MIT",
       "dependencies": {
-        "@vue/reactivity": "3.5.25",
-        "@vue/shared": "3.5.25"
+        "@vue/reactivity": "3.5.38",
+        "@vue/shared": "3.5.38"
       }
     },
     "node_modules/@vue/runtime-dom": {
-      "version": "3.5.25",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.25.tgz",
-      "integrity": "sha512-a4WrkYFbb19i9pjkz38zJBg8wa/rboNERq3+hRRb0dHiJh13c+6kAbgqCPfMaJ2gg4weWD3APZswASOfmKwamA==",
+      "version": "3.5.38",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.38.tgz",
+      "integrity": "sha512-apX2wt9sdfDshS+a2xueFZLVpt0GkRJZSoPmrW/SA4yzXTznhfcMVW59gr7h4YQeY0vJhdJkk2rsIDwgfFgC5A==",
       "license": "MIT",
       "dependencies": {
-        "@vue/reactivity": "3.5.25",
-        "@vue/runtime-core": "3.5.25",
-        "@vue/shared": "3.5.25",
-        "csstype": "^3.1.3"
+        "@vue/reactivity": "3.5.38",
+        "@vue/runtime-core": "3.5.38",
+        "@vue/shared": "3.5.38",
+        "csstype": "^3.2.3"
       }
     },
     "node_modules/@vue/server-renderer": {
-      "version": "3.5.25",
-      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.25.tgz",
-      "integrity": "sha512-UJaXR54vMG61i8XNIzTSf2Q7MOqZHpp8+x3XLGtE3+fL+nQd+k7O5+X3D/uWrnQXOdMw5VPih+Uremcw+u1woQ==",
+      "version": "3.5.38",
+      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.38.tgz",
+      "integrity": "sha512-vue8vbf2QlV4quHqzwmJy6dWfmRhP1J8l4wtZg60CL6VoKqcPY2oe7may3+1d9qfpedjK5PRLFqd5k3Isj9mUw==",
       "license": "MIT",
       "dependencies": {
-        "@vue/compiler-ssr": "3.5.25",
-        "@vue/shared": "3.5.25"
+        "@vue/compiler-ssr": "3.5.38",
+        "@vue/shared": "3.5.38"
       },
       "peerDependencies": {
-        "vue": "3.5.25"
+        "vue": "3.5.38"
       }
     },
     "node_modules/@vue/shared": {
-      "version": "3.5.25",
-      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.25.tgz",
-      "integrity": "sha512-AbOPdQQnAnzs58H2FrrDxYj/TJfmeS2jdfEEhgiKINy+bnOANmVizIEgq1r+C5zsbs6l1CCQxtcj71rwNQ4jWg==",
+      "version": "3.5.38",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.38.tgz",
+      "integrity": "sha512-FTW0AFZNaK5/mOqvGBwVfUlNLU38TiQn4+DQgIFUnrBBJQ1crMJ82yeGQLV5jyKFsO8yRukpbuP7x+nRbH6aug==",
       "license": "MIT"
     },
     "node_modules/@webext-core/fake-browser": {
@@ -1469,9 +1412,9 @@
       }
     },
     "node_modules/alien-signals": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/alien-signals/-/alien-signals-3.1.1.tgz",
-      "integrity": "sha512-ogkIWbVrLwKtHY6oOAXaYkAxP+cTH7V5FZ5+Tm4NZFd8VDZ6uNMDrfzqctTZ42eTMCSR3ne3otpcxmqSnFfPYA==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/alien-signals/-/alien-signals-3.2.1.tgz",
+      "integrity": "sha512-I8FjmltrfnDFoZedi5CG8DghVYNhzb/Ijluz7tCSJH0xpd0484Kowhbb1XDYOxfJpU1p5wnM2X54dA+IfGyD1g==",
       "dev": true,
       "license": "MIT"
     },
@@ -1714,19 +1657,6 @@
         "concat-map": "0.0.1"
       }
     },
-    "node_modules/braces": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
-      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fill-range": "^7.1.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
@@ -1751,24 +1681,24 @@
       }
     },
     "node_modules/c12": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/c12/-/c12-3.3.3.tgz",
-      "integrity": "sha512-750hTRvgBy5kcMNPdh95Qo+XUBeGo8C7nsKSmedDmaQI+E0r82DwHeM6vBewDe4rGFbnxoa4V9pw+sPh5+Iz8Q==",
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/c12/-/c12-3.3.4.tgz",
+      "integrity": "sha512-cM0ApFQSBXuourJejzwv/AuPRvAxordTyParRVcHjjtXirtkzM0uK2L9TTn9s0cXZbG7E55jCivRQzoxYmRAlA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "chokidar": "^5.0.0",
-        "confbox": "^0.2.2",
-        "defu": "^6.1.4",
-        "dotenv": "^17.2.3",
+        "confbox": "^0.2.4",
+        "defu": "^6.1.6",
+        "dotenv": "^17.3.1",
         "exsolve": "^1.0.8",
-        "giget": "^2.0.0",
+        "giget": "^3.2.0",
         "jiti": "^2.6.1",
         "ohash": "^2.0.11",
         "pathe": "^2.0.3",
-        "perfect-debounce": "^2.0.0",
+        "perfect-debounce": "^2.1.0",
         "pkg-types": "^2.3.0",
-        "rc9": "^2.1.2"
+        "rc9": "^3.0.1"
       },
       "peerDependencies": {
         "magicast": "*"
@@ -1777,36 +1707,6 @@
         "magicast": {
           "optional": true
         }
-      }
-    },
-    "node_modules/c12/node_modules/chokidar": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
-      "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "readdirp": "^5.0.0"
-      },
-      "engines": {
-        "node": ">= 20.19.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/c12/node_modules/readdirp": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
-      "integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 20.19.0"
-      },
-      "funding": {
-        "type": "individual",
-        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/cac": {
@@ -1846,16 +1746,16 @@
       }
     },
     "node_modules/chokidar": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
-      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
+      "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "readdirp": "^4.0.1"
+        "readdirp": "^5.0.0"
       },
       "engines": {
-        "node": ">= 14.16.0"
+        "node": ">= 20.19.0"
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
@@ -1923,9 +1823,9 @@
       }
     },
     "node_modules/ci-info": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.3.1.tgz",
-      "integrity": "sha512-Wdy2Igu8OcBpI2pZePZ5oWjPC38tmDVx5WKUXKwlLYkA0ozo85sLsLvkBbBn/sZaSCMFOGZJ14fvW9t5/d7kdA==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz",
+      "integrity": "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==",
       "dev": true,
       "funding": [
         {
@@ -1939,14 +1839,11 @@
       }
     },
     "node_modules/citty": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/citty/-/citty-0.1.6.tgz",
-      "integrity": "sha512-tskPPKEs8D2KPafUypv2gxwJP8h/OaJmC82QQGGDQcHvXX43xF2VDACcJVmZ0EuSxkpO9Kc4MlrA3q0+FG58AQ==",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/citty/-/citty-0.2.2.tgz",
+      "integrity": "sha512-+6vJA3L98yv+IdfKGZHBNiGW5KHn22e/JwID0Strsz8h4S/csAu/OuICwxrg44k5MRiZHWIo8XXuJgQTriRP4w==",
       "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "consola": "^3.2.3"
-      }
+      "license": "MIT"
     },
     "node_modules/cli-boxes": {
       "version": "3.0.0",
@@ -1972,19 +1869,6 @@
       },
       "engines": {
         "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/cli-spinners": {
-      "version": "2.9.2",
-      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
-      "integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -2172,9 +2056,9 @@
       }
     },
     "node_modules/confbox": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.2.2.tgz",
-      "integrity": "sha512-1NB+BKqhtNipMsov4xI/NnhCKp9XG9NamYp5PVm9klAT0fsrNPjaFICsCFhNhwZJKNh7zB/3q8qXz0E9oaMNtQ==",
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.2.4.tgz",
+      "integrity": "sha512-ysOGlgTFbN2/Y6Cg3Iye8YKulHw+R2fNXHrgSmXISQdMnomY6eNDprVdW9R5xBguEqI954+S6709UyiO7B+6OQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -2311,9 +2195,9 @@
       }
     },
     "node_modules/default-browser": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.4.0.tgz",
-      "integrity": "sha512-XDuvSq38Hr1MdN47EDvYtx3U0MTqpCEn+F6ft8z2vYDzMrvQhVp0ui9oQdqW3MvK3vqUETglt1tVGgjLuJ5izg==",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.5.0.tgz",
+      "integrity": "sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2354,9 +2238,9 @@
       }
     },
     "node_modules/defu": {
-      "version": "6.1.4",
-      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.4.tgz",
-      "integrity": "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==",
+      "version": "6.1.7",
+      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.7.tgz",
+      "integrity": "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -2466,9 +2350,9 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "17.2.3",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.3.tgz",
-      "integrity": "sha512-JVUnt+DUIzu87TABbhPmNfVdBDt18BLOWjMUFJMSi/Qqg7NTYtabbvSNJGOJ7afbRuv9D/lngizHtP7QyLQ+9w==",
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
       "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
@@ -2518,6 +2402,7 @@
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
       "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.12"
@@ -2661,23 +2546,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/fast-glob": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
-      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@nodelib/fs.stat": "^2.0.2",
-        "@nodelib/fs.walk": "^1.2.3",
-        "glob-parent": "^5.1.2",
-        "merge2": "^1.3.0",
-        "micromatch": "^4.0.8"
-      },
-      "engines": {
-        "node": ">=8.6.0"
-      }
-    },
     "node_modules/fast-redact": {
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-3.5.0.tgz",
@@ -2686,16 +2554,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/fastq": {
-      "version": "1.19.1",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
-      "integrity": "sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "reusify": "^1.0.4"
       }
     },
     "node_modules/fdir": {
@@ -2717,26 +2575,13 @@
       }
     },
     "node_modules/filesize": {
-      "version": "11.0.13",
-      "resolved": "https://registry.npmjs.org/filesize/-/filesize-11.0.13.tgz",
-      "integrity": "sha512-mYJ/qXKvREuO0uH8LTQJ6v7GsUvVOguqxg2VTwQUkyTPXXRRWPdjuUPVqdBrJQhvci48OHlNGRnux+Slr2Rnvw==",
+      "version": "11.0.17",
+      "resolved": "https://registry.npmjs.org/filesize/-/filesize-11.0.17.tgz",
+      "integrity": "sha512-oHLTvMLw6imZUl1se/RBQrFlyy50nXce4sU7yGR6Qc0JgCwqnfiFsAnEwotdGmfKLD7SArGUk2/5STU0k8LOBQ==",
       "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">= 10.8.0"
-      }
-    },
-    "node_modules/fill-range": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
-      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "to-regex-range": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/firefox-profile": {
@@ -2871,34 +2716,13 @@
       "license": "MIT"
     },
     "node_modules/giget": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/giget/-/giget-2.0.0.tgz",
-      "integrity": "sha512-L5bGsVkxJbJgdnwyuheIunkGatUF/zssUoxxjACCseZYAVbaqdh9Tsmmlkl8vYan09H7sbvKt4pS8GqKLBrEzA==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/giget/-/giget-3.3.0.tgz",
+      "integrity": "sha512-gzi2D96p+AMfDcmJHGDj3KJ9NRiwvlFAU5yfa3ROwWZmFUjX4P43x3BcyRaOMMLto1vUo7C+86+MFhYTl6Ryiw==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "citty": "^0.1.6",
-        "consola": "^3.4.0",
-        "defu": "^6.1.4",
-        "node-fetch-native": "^1.6.6",
-        "nypm": "^0.6.0",
-        "pathe": "^2.0.3"
-      },
       "bin": {
         "giget": "dist/cli.mjs"
-      }
-    },
-    "node_modules/glob-parent": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "is-glob": "^4.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/glob-to-regexp": {
@@ -2956,9 +2780,9 @@
       "license": "MIT"
     },
     "node_modules/hookable": {
-      "version": "5.5.3",
-      "resolved": "https://registry.npmjs.org/hookable/-/hookable-5.5.3.tgz",
-      "integrity": "sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/hookable/-/hookable-6.1.1.tgz",
+      "integrity": "sha512-U9LYDy1CwhMCnprUfeAZWZGByVbhd54hwepegYTK7Pi5NvqEj63ifz5z+xukznehT7i6NIZRu89Ay1AZmRsLEQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -3073,16 +2897,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/is-extglob": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/is-fullwidth-code-point": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-4.0.0.tgz",
@@ -3096,19 +2910,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/is-glob": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
-      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-extglob": "^2.1.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/is-in-ci": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-in-ci/-/is-in-ci-1.0.0.tgz",
@@ -3120,6 +2921,19 @@
       },
       "engines": {
         "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-in-ssh": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-in-ssh/-/is-in-ssh-1.0.0.tgz",
+      "integrity": "sha512-jYa6Q9rH90kR1vKB6NM7qqd1mge3Fx4Dhw5TVlK1MUBqhEOuCagrEHMevNuCcbECmXZ0ThXkRm+Ymr51HwEPAw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -3161,19 +2975,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/is-interactive": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-2.0.0.tgz",
-      "integrity": "sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/is-npm": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-6.1.0.tgz",
@@ -3185,16 +2986,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/is-number": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.12.0"
       }
     },
     "node_modules/is-path-inside": {
@@ -3249,23 +3040,10 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/is-unicode-supported": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
-      "integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/is-wsl": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.0.tgz",
-      "integrity": "sha512-UcVfVfaK4Sc4m7X3dUSoHoozQGBEFeDC+zVo06t98xe8CzHSZZBekNXH+tu0NalHolcJ/QAGqS46Hef7QXBIMw==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
+      "integrity": "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3524,36 +3302,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/log-symbols": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-6.0.0.tgz",
-      "integrity": "sha512-i24m8rpwhmPIS4zscNzK6MSEhk0DUWa/8iYQWxhffV8jkI4Phvs3F+quL5xvS0gdQR0FyTCMMH33Y78dDTzzIw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^5.3.0",
-        "is-unicode-supported": "^1.3.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/log-symbols/node_modules/is-unicode-supported": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-1.3.0.tgz",
-      "integrity": "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/log-update": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/log-update/-/log-update-6.1.0.tgz",
@@ -3617,15 +3365,15 @@
       }
     },
     "node_modules/magicast": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.3.5.tgz",
-      "integrity": "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==",
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.3.tgz",
+      "integrity": "sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.25.4",
-        "@babel/types": "^7.25.4",
-        "source-map-js": "^1.2.0"
+        "@babel/parser": "^7.29.3",
+        "@babel/types": "^7.29.0",
+        "source-map-js": "^1.2.1"
       }
     },
     "node_modules/make-error": {
@@ -3652,43 +3400,6 @@
       "dev": true,
       "license": "Apache-2.0"
     },
-    "node_modules/merge2": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
-      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/micromatch": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
-      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "braces": "^3.0.3",
-        "picomatch": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=8.6"
-      }
-    },
-    "node_modules/micromatch/node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
     "node_modules/mimic-function": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
@@ -3700,22 +3411,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/minimatch": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.1.1.tgz",
-      "integrity": "sha512-enIvLvRAFZYXJzkCYG5RKmPfrFArdLv+R+lbQ53BmIMLIry74bjKzX6iHAm8WYamJkhSSEabrWN5D97XnKObjQ==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "@isaacs/brace-expansion": "^5.0.0"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/minimist": {
@@ -3807,9 +3502,9 @@
       }
     },
     "node_modules/nano-spawn": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/nano-spawn/-/nano-spawn-1.0.3.tgz",
-      "integrity": "sha512-jtpsQDetTnvS2Ts1fiRdci5rx0VYws5jGyC+4IYOTnIQ/wwdf6JdomlHBwqC3bJYOvaKu0C2GSZ1A60anrYpaA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/nano-spawn/-/nano-spawn-2.1.0.tgz",
+      "integrity": "sha512-yTW+2okrElHiH4fsiz/+/zc0EDo9BDDoC3iKk8dpv1GeRc9nUWzUZHx6TofMWErchhUQR8hY9/Eu1Uja9x1nqA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3820,9 +3515,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.15",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
+      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
       "funding": [
         {
           "type": "github",
@@ -3835,6 +3530,16 @@
       },
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/nanospinner": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/nanospinner/-/nanospinner-1.2.2.tgz",
+      "integrity": "sha512-Zt/AmG6qRU3e+WnzGGLuMCEAO/dAu45stNbHY223tUxldaDAeE+FxSPsd9Q+j+paejmm0ZbrNVs5Sraqy3dRxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "picocolors": "^1.1.1"
       }
     },
     "node_modules/node-fetch-native": {
@@ -3945,23 +3650,21 @@
       }
     },
     "node_modules/nypm": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/nypm/-/nypm-0.6.2.tgz",
-      "integrity": "sha512-7eM+hpOtrKrBDCh7Ypu2lJ9Z7PNZBdi/8AT3AX8xoCj43BBVHD0hPSTEvMtkMpfs8FCqBGhxB+uToIQimA111g==",
+      "version": "0.6.7",
+      "resolved": "https://registry.npmjs.org/nypm/-/nypm-0.6.7.tgz",
+      "integrity": "sha512-s3ds97SD5pd1dULE+tHUk1DrV0cSHOnsfpcdGATJ8JpBo21DoKqN9exTH4/2nhPQNOLomBdTFMicN94S4DrZrQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "citty": "^0.1.6",
-        "consola": "^3.4.2",
+        "citty": "^0.2.2",
         "pathe": "^2.0.3",
-        "pkg-types": "^2.3.0",
-        "tinyexec": "^1.0.1"
+        "tinyexec": "^1.2.4"
       },
       "bin": {
         "nypm": "dist/cli.mjs"
       },
       "engines": {
-        "node": "^14.16.0 || >=16.10.0"
+        "node": ">=18"
       }
     },
     "node_modules/obug": {
@@ -4021,43 +3724,21 @@
       }
     },
     "node_modules/open": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/open/-/open-10.2.0.tgz",
-      "integrity": "sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==",
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-11.0.0.tgz",
+      "integrity": "sha512-smsWv2LzFjP03xmvFoJ331ss6h+jixfA4UUV/Bsiyuu4YJPfN+FIQGOIiv4w9/+MoHkfkJ22UIaQWRVFRfH6Vw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "default-browser": "^5.2.1",
+        "default-browser": "^5.4.0",
         "define-lazy-prop": "^3.0.0",
+        "is-in-ssh": "^1.0.0",
         "is-inside-container": "^1.0.0",
-        "wsl-utils": "^0.1.0"
+        "powershell-utils": "^0.1.0",
+        "wsl-utils": "^0.3.0"
       },
       "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/ora": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/ora/-/ora-8.2.0.tgz",
-      "integrity": "sha512-weP+BZ8MVNnlCm8c0Qdc1WSWq4Qn7I+9CJGm7Qali6g44e/PUzbjNqJX5NJ9ljlNMosfJvg1fKEGILklK9cwnw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^5.3.0",
-        "cli-cursor": "^5.0.0",
-        "cli-spinners": "^2.9.2",
-        "is-interactive": "^2.0.0",
-        "is-unicode-supported": "^2.0.0",
-        "log-symbols": "^6.0.0",
-        "stdin-discarder": "^0.2.2",
-        "string-width": "^7.2.0",
-        "strip-ansi": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=18"
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -4133,9 +3814,9 @@
       "license": "MIT"
     },
     "node_modules/perfect-debounce": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-2.0.0.tgz",
-      "integrity": "sha512-fkEH/OBiKrqqI/yIgjR92lMfs2K8105zt/VT6+7eTjNwisrsh47CeIED9z58zI7DfKdH3uHAn25ziRZn3kgAow==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-2.1.0.tgz",
+      "integrity": "sha512-LjgdTytVFXeUgtHZr9WYViYSM/g8MkcTPYDlPa3cDqMirHjKiSZPYd6DoL7pK8AJQr+uWkQvCjHNdiMqsrJs+g==",
       "dev": true,
       "license": "MIT"
     },
@@ -4146,9 +3827,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4211,9 +3892,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
       "funding": [
         {
           "type": "opencollective",
@@ -4230,12 +3911,25 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/powershell-utils": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/powershell-utils/-/powershell-utils-0.1.0.tgz",
+      "integrity": "sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/process-nextick-args": {
@@ -4349,27 +4043,6 @@
       ],
       "license": "MIT"
     },
-    "node_modules/queue-microtask": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
-      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
     "node_modules/quick-format-unescaped": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
@@ -4411,14 +4084,14 @@
       }
     },
     "node_modules/rc9": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/rc9/-/rc9-2.1.2.tgz",
-      "integrity": "sha512-btXCnMmRIBINM2LDZoEmOogIZU7Qe7zn4BpomSKZ/ykbLObuBdvG+mFq11DL6fjH1DRwHhrlgtYWG96bJiC7Cg==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/rc9/-/rc9-3.0.1.tgz",
+      "integrity": "sha512-gMDyleLWVE+i6Sgtc0QbbY6pEKqYs97NGi6isHQPqYlLemPoO8dxQ3uGi0f4NiP98c+jMW6cG1Kx9dDwfvqARQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "defu": "^6.1.4",
-        "destr": "^2.0.3"
+        "defu": "^6.1.6",
+        "destr": "^2.0.5"
       }
     },
     "node_modules/readable-stream": {
@@ -4438,13 +4111,13 @@
       }
     },
     "node_modules/readdirp": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
-      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
+      "integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">= 14.18.0"
+        "node": ">= 20.19.0"
       },
       "funding": {
         "type": "individual",
@@ -4517,17 +4190,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/reusify": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
-      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "iojs": ">=1.0.0",
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/rfdc": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
@@ -4588,30 +4250,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/run-parallel": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
-      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "queue-microtask": "^1.2.2"
       }
     },
     "node_modules/safe-buffer": {
@@ -4820,19 +4458,6 @@
         "node": ">= 10.x"
       }
     },
-    "node_modules/stdin-discarder": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/stdin-discarder/-/stdin-discarder-0.2.2.tgz",
-      "integrity": "sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/string_decoder": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
@@ -4951,9 +4576,9 @@
       "license": "MIT"
     },
     "node_modules/tinyexec": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.2.tgz",
-      "integrity": "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4961,14 +4586,14 @@
       }
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.15",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
-      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
-        "picomatch": "^4.0.3"
+        "picomatch": "^4.0.4"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -4985,19 +4610,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=14.14"
-      }
-    },
-    "node_modules/to-regex-range": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-number": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=8.0"
       }
     },
     "node_modules/tslib": {
@@ -5028,9 +4640,9 @@
       "license": "MIT"
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
@@ -5289,16 +4901,16 @@
       "license": "MIT"
     },
     "node_modules/vue": {
-      "version": "3.5.25",
-      "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.25.tgz",
-      "integrity": "sha512-YLVdgv2K13WJ6n+kD5owehKtEXwdwXuj2TTyJMsO7pSeKw2bfRNZGjhB7YzrpbMYj5b5QsUebHpOqR3R3ziy/g==",
+      "version": "3.5.38",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.38.tgz",
+      "integrity": "sha512-vAMKHfImQlYSy0C+PBue4s3ERZ2xGKfgZg5GXAsLInq1dyh2H78ILVP5sK0KPFPVW4kv+OGCIvBEondcjpZp7A==",
       "license": "MIT",
       "dependencies": {
-        "@vue/compiler-dom": "3.5.25",
-        "@vue/compiler-sfc": "3.5.25",
-        "@vue/runtime-dom": "3.5.25",
-        "@vue/server-renderer": "3.5.25",
-        "@vue/shared": "3.5.25"
+        "@vue/compiler-dom": "3.5.38",
+        "@vue/compiler-sfc": "3.5.38",
+        "@vue/runtime-dom": "3.5.38",
+        "@vue/server-renderer": "3.5.38",
+        "@vue/shared": "3.5.38"
       },
       "peerDependencies": {
         "typescript": "*"
@@ -5310,14 +4922,14 @@
       }
     },
     "node_modules/vue-tsc": {
-      "version": "3.1.8",
-      "resolved": "https://registry.npmjs.org/vue-tsc/-/vue-tsc-3.1.8.tgz",
-      "integrity": "sha512-deKgwx6exIHeZwF601P1ktZKNF0bepaSN4jBU3AsbldPx9gylUc1JDxYppl82yxgkAgaz0Y0LCLOi+cXe9HMYA==",
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/vue-tsc/-/vue-tsc-3.3.5.tgz",
+      "integrity": "sha512-Rzh/G2MmNlMSAMTiQEjDrsb4dgB/jbtEM47rVN2NtidF1dfb/q4w4QvpQBtW5+y3y5H27Hjh7deVwk+YB02fNg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@volar/typescript": "2.4.26",
-        "@vue/language-core": "3.1.8"
+        "@volar/typescript": "2.4.28",
+        "@vue/language-core": "3.3.5"
       },
       "bin": {
         "vue-tsc": "bin/vue-tsc.js"
@@ -5450,80 +5062,101 @@
       }
     },
     "node_modules/wsl-utils": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.1.0.tgz",
-      "integrity": "sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.3.1.tgz",
+      "integrity": "sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "is-wsl": "^3.1.0"
+        "is-wsl": "^3.1.0",
+        "powershell-utils": "^0.1.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/wxt": {
-      "version": "0.20.13",
-      "resolved": "https://registry.npmjs.org/wxt/-/wxt-0.20.13.tgz",
-      "integrity": "sha512-FwQEk+0a4/pYha6rTKGl5iicU6kRYDBDiElJf55CFEfoJKqvGzBTZpphafurQfqU1X0hvAm9w5GEWC0thXI6wQ==",
+      "version": "0.20.27",
+      "resolved": "https://registry.npmjs.org/wxt/-/wxt-0.20.27.tgz",
+      "integrity": "sha512-dm6yixz2awM4YMqpTJnsCa8aOPiTrjiIjbWslgR5hCjgwhuft+hLlla339Dt7gIKwQloee4oOruoK++vaX0APA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@1natsu/wait-element": "^4.1.2",
         "@aklinker1/rollup-plugin-visualizer": "5.12.0",
-        "@webext-core/fake-browser": "^1.3.2",
-        "@webext-core/isolated-element": "^1.1.2",
+        "@webext-core/fake-browser": "^1.3.4",
+        "@webext-core/isolated-element": "^1.1.3",
         "@webext-core/match-patterns": "^1.0.3",
-        "@wxt-dev/browser": "^0.1.32",
+        "@wxt-dev/browser": "^0.2.0",
         "@wxt-dev/storage": "^1.0.0",
         "async-mutex": "^0.5.0",
-        "c12": "^3.3.2",
-        "cac": "^6.7.14",
-        "chokidar": "^4.0.3",
-        "ci-info": "^4.3.1",
+        "c12": "^3.3.4",
+        "cac": "^6.7.14 || ^7.0.0",
+        "chokidar": "^5.0.0",
+        "ci-info": "^4.4.0",
         "consola": "^3.4.2",
         "defu": "^6.1.4",
-        "dotenv": "^17.2.3",
         "dotenv-expand": "^12.0.3",
         "esbuild": "^0.27.1",
-        "fast-glob": "^3.3.3",
-        "filesize": "^11.0.13",
-        "fs-extra": "^11.3.2",
+        "filesize": "^11.0.17",
         "get-port-please": "^3.2.0",
-        "giget": "^1.2.3 || ^2.0.0",
-        "hookable": "^5.5.3",
+        "giget": "^1.2.3 || ^2.0.0 || ^3.0.0",
+        "hookable": "^6.1.0",
         "import-meta-resolve": "^4.2.0",
-        "is-wsl": "^3.1.0",
+        "is-wsl": "^3.1.1",
         "json5": "^2.2.3",
         "jszip": "^3.10.1",
         "linkedom": "^0.18.12",
-        "magicast": "^0.3.5",
-        "minimatch": "^10.1.1",
-        "nano-spawn": "^1.0.3",
+        "magicast": "^0.5.2",
+        "nano-spawn": "^2.0.0",
+        "nanospinner": "^1.2.2",
         "normalize-path": "^3.0.0",
-        "nypm": "^0.6.2",
+        "nypm": "^0.6.5",
         "ohash": "^2.0.11",
-        "open": "^10.2.0",
-        "ora": "^8.2.0",
-        "perfect-debounce": "^2.0.0",
-        "picocolors": "^1.1.1",
+        "open": "^11.0.0",
+        "perfect-debounce": "^2.1.0",
+        "picomatch": "^4.0.3",
         "prompts": "^2.4.2",
-        "publish-browser-extension": "^2.3.0 || ^3.0.2",
+        "publish-browser-extension": "^2.3.0 || ^3.0.2 || ^4.0.5",
         "scule": "^1.3.0",
-        "unimport": "^3.13.1 || ^4.0.0 || ^5.0.0",
-        "vite": "^5.4.19 || ^6.3.4 || ^7.0.0",
-        "vite-node": "^3.2.4 || ^5.0.0",
+        "tinyglobby": "^0.2.16",
+        "unimport": "^3.13.1 || ^4.0.0 || ^5.0.0 || ^6.0.0",
+        "vite": "^5.4.19 || ^6.3.4 || ^7.0.0 || ^8.0.0-0",
+        "vite-node": "^3.2.4 || ^5.0.0 || ^6.0.0",
         "web-ext-run": "^0.2.4"
       },
       "bin": {
         "wxt": "bin/wxt.mjs",
-        "wxt-publish-extension": "bin/wxt-publish-extension.cjs"
+        "wxt-publish-extension": "bin/wxt-publish-extension.mjs"
+      },
+      "engines": {
+        "bun": ">=1.2.0",
+        "node": ">=20.12.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/wxt-dev"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "eslint": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/wxt/node_modules/@wxt-dev/browser": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@wxt-dev/browser/-/browser-0.2.0.tgz",
+      "integrity": "sha512-gURcpkDUknl6FGe8LTsFqv4ZWfi/EacAalJ18qmtVzOnicCZRKkIGK2SApO7JxG4Ig589UexM/CADbKJ66h8aw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/filesystem": "*",
+        "@types/har-format": "*"
       }
     },
     "node_modules/xdg-basedir": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "twenty-crm-linkedin-extension",
   "description": "Chrome extension to capture LinkedIn profiles and companies to Twenty CRM",
   "private": true,
-  "version": "1.0.0",
+  "version": "1.1.0",
   "type": "module",
   "scripts": {
     "dev": "wxt",
@@ -15,12 +15,12 @@
     "postinstall": "wxt prepare"
   },
   "dependencies": {
-    "vue": "^3.5.25"
+    "vue": "^3.5.38"
   },
   "devDependencies": {
     "@wxt-dev/module-vue": "^1.0.3",
-    "typescript": "^5.9.3",
-    "vue-tsc": "^3.1.8",
-    "wxt": "^0.20.6"
+    "typescript": "^6.0.3",
+    "vue-tsc": "^3.3.5",
+    "wxt": "^0.20.27"
   }
 }

--- a/types/index.ts
+++ b/types/index.ts
@@ -56,17 +56,6 @@ export type TwentyCompany = {
   idealCustomerProfile?: boolean;
 };
 
-export type TwentyTokenPair = {
-  accessOrWorkspaceAgnosticToken: {
-    token: string;
-    expiresAt: string;
-  };
-  refreshToken: {
-    token: string;
-    expiresAt: string;
-  };
-};
-
 // Extension State Types
 export type CaptureStatus = 
   | 'idle'
@@ -114,6 +103,7 @@ export type ExtensionResponse<T = unknown> = {
 // Settings
 export type ExtensionSettings = {
   twentyUrl: string;
+  apiKey: string;
 };
 
 // GraphQL Response Types

--- a/utils/countries.ts
+++ b/utils/countries.ts
@@ -1,0 +1,63 @@
+// Country names used to detect the country segment of a LinkedIn location
+// string. LinkedIn formats locations as "City, Region, Country", so we validate
+// the last segment against this list. Common aliases (UK, USA, UAE, …) included.
+const COUNTRY_NAMES: string[] = [
+  'Afghanistan', 'Albania', 'Algeria', 'Andorra', 'Angola', 'Antigua and Barbuda',
+  'Argentina', 'Armenia', 'Australia', 'Austria', 'Azerbaijan', 'Bahamas', 'Bahrain',
+  'Bangladesh', 'Barbados', 'Belarus', 'Belgium', 'Belize', 'Benin', 'Bhutan', 'Bolivia',
+  'Bosnia and Herzegovina', 'Botswana', 'Brazil', 'Brunei', 'Bulgaria', 'Burkina Faso',
+  'Burundi', 'Cambodia', 'Cameroon', 'Canada', 'Cape Verde', 'Central African Republic',
+  'Chad', 'Chile', 'China', 'Colombia', 'Comoros', 'Congo', 'Costa Rica', 'Croatia',
+  'Cuba', 'Cyprus', 'Czechia', 'Czech Republic', 'Denmark', 'Djibouti', 'Dominica',
+  'Dominican Republic', 'Ecuador', 'Egypt', 'El Salvador', 'Equatorial Guinea', 'Eritrea',
+  'Estonia', 'Eswatini', 'Ethiopia', 'Fiji', 'Finland', 'France', 'Gabon', 'Gambia',
+  'Georgia', 'Germany', 'Ghana', 'Greece', 'Grenada', 'Guatemala', 'Guinea',
+  'Guinea-Bissau', 'Guyana', 'Haiti', 'Honduras', 'Hong Kong', 'Hungary', 'Iceland',
+  'India', 'Indonesia', 'Iran', 'Iraq', 'Ireland', 'Israel', 'Italy', 'Ivory Coast',
+  'Jamaica', 'Japan', 'Jordan', 'Kazakhstan', 'Kenya', 'Kiribati', 'Kosovo', 'Kuwait',
+  'Kyrgyzstan', 'Laos', 'Latvia', 'Lebanon', 'Lesotho', 'Liberia', 'Libya',
+  'Liechtenstein', 'Lithuania', 'Luxembourg', 'Macau', 'Madagascar', 'Malawi', 'Malaysia',
+  'Maldives', 'Mali', 'Malta', 'Marshall Islands', 'Mauritania', 'Mauritius', 'Mexico',
+  'Micronesia', 'Moldova', 'Monaco', 'Mongolia', 'Montenegro', 'Morocco', 'Mozambique',
+  'Myanmar', 'Namibia', 'Nauru', 'Nepal', 'Netherlands', 'New Zealand', 'Nicaragua',
+  'Niger', 'Nigeria', 'North Korea', 'North Macedonia', 'Norway', 'Oman', 'Pakistan',
+  'Palau', 'Palestine', 'Panama', 'Papua New Guinea', 'Paraguay', 'Peru', 'Philippines',
+  'Poland', 'Portugal', 'Qatar', 'Romania', 'Russia', 'Rwanda', 'Saint Kitts and Nevis',
+  'Saint Lucia', 'Saint Vincent and the Grenadines', 'Samoa', 'San Marino',
+  'Sao Tome and Principe', 'Saudi Arabia', 'Senegal', 'Serbia', 'Seychelles',
+  'Sierra Leone', 'Singapore', 'Slovakia', 'Slovenia', 'Solomon Islands', 'Somalia',
+  'South Africa', 'South Korea', 'South Sudan', 'Spain', 'Sri Lanka', 'Sudan', 'Suriname',
+  'Sweden', 'Switzerland', 'Syria', 'Taiwan', 'Tajikistan', 'Tanzania', 'Thailand',
+  'Timor-Leste', 'Togo', 'Tonga', 'Trinidad and Tobago', 'Tunisia', 'Turkey', 'Turkmenistan',
+  'Tuvalu', 'Uganda', 'Ukraine', 'United Arab Emirates', 'United Kingdom', 'United States',
+  'Uruguay', 'Uzbekistan', 'Vanuatu', 'Vatican City', 'Venezuela', 'Vietnam', 'Yemen',
+  'Zambia', 'Zimbabwe',
+  // Common aliases LinkedIn or users may use
+  'UK', 'U.K.', 'USA', 'U.S.A.', 'U.S.', 'United States of America', 'UAE', 'Russia',
+  'South Korea', 'Korea',
+];
+
+const COUNTRY_SET = new Set(COUNTRY_NAMES.map((c) => c.toLowerCase()));
+
+// Maps an alias to a cleaner canonical country name (others pass through as-is).
+const CANONICAL: Record<string, string> = {
+  'uk': 'United Kingdom',
+  'u.k.': 'United Kingdom',
+  'usa': 'United States',
+  'u.s.a.': 'United States',
+  'u.s.': 'United States',
+  'united states of america': 'United States',
+  'uae': 'United Arab Emirates',
+  'korea': 'South Korea',
+  'czech republic': 'Czechia',
+};
+
+export function isCountryName(value: string): boolean {
+  return COUNTRY_SET.has(value.trim().toLowerCase());
+}
+
+// Returns the canonical country name for a value known to be a country.
+export function canonicalCountry(value: string): string {
+  const key = value.trim().toLowerCase();
+  return CANONICAL[key] || value.trim();
+}

--- a/utils/linkedin-scraper.ts
+++ b/utils/linkedin-scraper.ts
@@ -22,52 +22,160 @@ export function getLinkedInIdentifier(url: string): string | null {
   return null;
 }
 
+// Resolve the profile's display name from the most stable sources available.
+// Visible <h1> first (structural, class-independent), then the page title and
+// og:title meta as resilient fallbacks for when LinkedIn reshuffles the DOM.
+function getProfileName(): string {
+  const h1 =
+    document.querySelector('main h1') ||
+    document.querySelector('h1.text-heading-xlarge') || // legacy
+    document.querySelector('h1[class*="break-words"]') ||
+    document.querySelector('.pv-top-card h1') ||
+    document.querySelector('h1'); // last resort: first heading on the page
+  const fromH1 = h1?.textContent?.trim() || '';
+  if (fromH1) return fromH1;
+
+  // Page title, e.g. "(3) John Doe | LinkedIn" -> "John Doe"
+  const fromTitle = document.title
+    .replace(/^\(\d+\+?\)\s*/, '')          // strip notification count
+    .replace(/\s*\|\s*LinkedIn\b.*$/i, '')  // strip "| LinkedIn ..."
+    .trim();
+  if (fromTitle && !/^linkedin$/i.test(fromTitle)) return fromTitle;
+
+  // og:title meta, e.g. "John Doe - Title - Company | LinkedIn" -> "John Doe"
+  const og = document.querySelector('meta[property="og:title"]')?.getAttribute('content') || '';
+  return og.split(/\s+[|–—-]\s+/)[0].trim();
+}
+
+// Modern LinkedIn obfuscates every class name, so we anchor on stable, semantic
+// landmarks instead. The "Contact info" link (a stable URL fragment) lives in the
+// location row; that row's parent is the info block that also holds the headline
+// and the "Company · School" line as sibling <p>s.
+function getInfoBlock(): Element | null {
+  const contactLink = document.querySelector('a[href*="contact-info"]');
+  const locationRow = contactLink?.closest('div');
+  return locationRow?.parentElement || null;
+}
+
+// Direct <p> children of the info block, in document order:
+//   [0] = headline, [1] = "Company · School" (when present).
+function infoBlockParagraphs(block: Element | null): string[] {
+  if (!block) return [];
+  return Array.from(block.children)
+    .filter((c) => c.tagName === 'P')
+    .map((p) => p.textContent?.trim() || '')
+    .filter(Boolean);
+}
+
+// Headline / current role shown under the name.
+function getHeadline(block: Element | null): string {
+  // Legacy LinkedIn (still served in some locales / older instances)
+  const legacy =
+    document.querySelector('div[data-generated-suggestion-target]') ||
+    document.querySelector('.text-body-medium.break-words') ||
+    document.querySelector('.text-body-medium');
+  const fromLegacy = legacy?.textContent?.trim() || '';
+  if (fromLegacy) return fromLegacy;
+
+  // Modern: first <p> of the info block
+  return infoBlockParagraphs(block)[0] || '';
+}
+
+// Location line (e.g. "Singapore"): the first non-separator <p> in the same row
+// as the Contact info link.
+function getLocation(): string {
+  const contactLink = document.querySelector('a[href*="contact-info"]');
+  const locationRow = contactLink?.closest('div');
+  if (locationRow) {
+    for (const p of Array.from(locationRow.querySelectorAll(':scope > p'))) {
+      const text = p.textContent?.trim() || '';
+      if (text && text !== '·' && !/contact info/i.test(text)) return text;
+    }
+  }
+
+  // Legacy fallback
+  const legacy = document.querySelector(
+    'span.text-body-small.inline.t-black--light.break-words'
+  );
+  return legacy?.textContent?.trim() || '';
+}
+
+// Current company. The modern profile renders it as an entity button whose
+// figure carries an <svg id="company-accent-…">; the company name is the <p>
+// inside that button. Falls back to the "Company · School" line, then legacy.
+function getCurrentCompany(block: Element | null): { name: string; linkedinUrl?: string } | null {
+  const companySvg = document.querySelector('[role="button"] svg[id*="company"]');
+  const companyBtn = companySvg?.closest('[role="button"]');
+  const btnName = companyBtn?.querySelector('p')?.textContent?.trim();
+  if (btnName) {
+    const link = companyBtn?.querySelector('a[href*="/company/"]');
+    const href = link?.getAttribute('href') || '';
+    const match = href.match(/\/company\/([^/?]+)/);
+    return {
+      name: btnName,
+      linkedinUrl: match ? `https://www.linkedin.com/company/${match[1]}/` : undefined,
+    };
+  }
+
+  // Fallback: the "Company · School" paragraph -> take the part before "·"
+  const companyLine = infoBlockParagraphs(block)[1];
+  if (companyLine) {
+    const company = companyLine.split('·')[0].trim();
+    if (company) return { name: company };
+  }
+
+  // Legacy aria-label based detection (older LinkedIn)
+  return scrapeCurrentCompanyFromProfile();
+}
+
 // Scrape person profile data from LinkedIn page
 export function scrapePersonProfile(): LinkedInProfileData | null {
   try {
     const linkedinUrl = window.location.href.split('?')[0];
     
-    // Get name - LinkedIn uses h1 for the profile name with various class combinations
-    // Try multiple selectors as LinkedIn frequently changes their DOM
-    const nameElement = 
-      document.querySelector('h1.text-heading-xlarge') ||  // Old format
-      document.querySelector('h1.inline.t-24') ||          // New format (2024+)
-      document.querySelector('h1.t-24.v-align-middle') ||  // Another variant
-      document.querySelector('.pv-top-card h1') ||         // Fallback: h1 in top card
-      document.querySelector('h1[class*="break-words"]');  // Generic fallback
-    
-    if (!nameElement) {
-      console.warn('Could not find name element - tried multiple selectors');
+    // Get name. Class names churn constantly, so prefer structural selectors and
+    // fall back to the page title / og:title, which are far more stable.
+    const fullName = getProfileName();
+
+    if (!fullName) {
+      const h1s = Array.from(document.querySelectorAll('h1'))
+        .map((h) => h.textContent?.trim())
+        .filter(Boolean);
+      console.warn(
+        'Could not extract profile name. h1 candidates:', h1s,
+        '| document.title:', document.title
+      );
       return null;
     }
-    
-    const fullName = nameElement.textContent?.trim() || '';
     console.log('Scraped name:', fullName);
     const nameParts = parseFullName(fullName);
-    
-    // Get headline/title - div with text-body-medium class that has job title
-    // Use data-generated-suggestion-target attribute as it's more reliable
-    const headlineElement = 
-      document.querySelector('div[data-generated-suggestion-target]') ||
-      document.querySelector('div.text-body-medium.break-words');
-    const headline = headlineElement?.textContent?.trim() || '';
+
+    // The info block (headline + company line + location) anchored on the
+    // stable "Contact info" link rather than obfuscated class names.
+    const infoBlock = getInfoBlock();
+
+    const headline = getHeadline(infoBlock);
+    if (!headline) {
+      console.warn('Could not extract headline. Info block <p> candidates:',
+        infoBlockParagraphs(infoBlock));
+    }
     console.log('Scraped headline:', headline);
-    
+
     // Get current company info
-    const companyData = scrapeCurrentCompanyFromProfile();
+    const companyData = getCurrentCompany(infoBlock);
     const currentCompany = companyData?.name || extractCompanyFromHeadline(headline);
     console.log('Scraped company data:', companyData);
     console.log('Current company:', currentCompany);
-    
-    // Get profile image - try to get high quality version
-    const profileImageUrl = scrapeProfileImage();
-    
-    // Get location - span with location info
-    const locationElement = 
-      document.querySelector('span.text-body-small.inline.t-black--light.break-words') ||
-      document.querySelector('.text-body-small.inline.t-black--light.break-words') ||
-      document.querySelector('.pv-top-card--list-bullet li:last-child');
-    const location = locationElement?.textContent?.trim() || '';
+
+    // Get profile image - prefer the owner's photo (alt matches their name)
+    const profileImageUrl = scrapeProfileImage(fullName);
+
+    // Get location
+    const location = getLocation();
+    if (!location) {
+      console.warn('Could not extract location. Contact-info anchor present:',
+        !!document.querySelector('a[href*="contact-info"]'));
+    }
     console.log('Scraped location:', location);
     
     const result = {
@@ -96,28 +204,56 @@ export function scrapePersonProfile(): LinkedInProfileData | null {
   }
 }
 
-// Scrape profile image
-function scrapeProfileImage(): string {
-  // Try multiple selectors - LinkedIn changes DOM frequently
+// Scrape the profile owner's photo. On modern LinkedIn many "profile-displayphoto"
+// images belong to OTHER people (mutual connections), so we match on the owner's
+// name in alt/title first; those decorative images have empty alt.
+function scrapeProfileImage(fullName: string): string {
+  const isOwnerPhoto = (img: HTMLImageElement | null): boolean =>
+    !!img?.src && !img.src.includes('ghost') &&
+    /licdn\.com|profile-displayphoto|profile-photo/i.test(img.src);
+
+  // 1. Modern: the owner's photo is wrapped in an element labelled "Profile photo"
+  //    (the cover photo and mutual-connection thumbnails are not).
+  const labelled = document.querySelector('[aria-label="Profile photo"] img') as HTMLImageElement | null;
+  if (isOwnerPhoto(labelled)) {
+    console.log('Scraped profile image (labelled):', labelled!.src);
+    return labelled!.src;
+  }
+  const topcard = document.querySelector('a[componentkey*="topcard-logo-image"] img') as HTMLImageElement | null;
+  if (isOwnerPhoto(topcard)) {
+    console.log('Scraped profile image (topcard):', topcard!.src);
+    return topcard!.src;
+  }
+
+  // 2. The owner's photo may carry their name in alt/title
+  if (fullName) {
+    const nameImg = Array.from(document.querySelectorAll('img'))
+      .find((img) => {
+        const label = `${img.getAttribute('alt') || ''} ${img.getAttribute('title') || ''}`;
+        return label.toLowerCase().includes(fullName.toLowerCase()) && isOwnerPhoto(img);
+      });
+    if (nameImg) {
+      console.log('Scraped profile image (by name):', nameImg.src);
+      return nameImg.src;
+    }
+  }
+
+  // 3. Legacy selectors
   const selectors = [
-    '.pv-top-card-profile-picture__container img',  // New format with button wrapper
-    '.pv-top-card-profile-picture__image',          // Old format
+    '.pv-top-card-profile-picture__container img',
+    '.pv-top-card-profile-picture__image',
     'img.profile-photo-edit__preview',
     '.pv-top-card__photo img',
-    'button[aria-label*="image"] img',              // Button with image label
-    '.EntityPhoto-circle-9 img',                    // Entity photo class
-    'img[title]',                                   // Fallback: img with title (usually name)
+    'button[aria-label*="image"] img',
   ];
-  
   for (const selector of selectors) {
     const img = document.querySelector(selector) as HTMLImageElement;
-    if (img?.src && !img.src.includes('ghost') && img.src.includes('profile')) {
-      // Use the URL as-is - LinkedIn URLs have signed params that break if modified
-      console.log('Scraped profile image:', img.src);
+    if (isOwnerPhoto(img)) {
+      console.log('Scraped profile image (legacy):', img.src);
       return img.src;
     }
   }
-  
+
   return '';
 }
 

--- a/utils/storage.ts
+++ b/utils/storage.ts
@@ -6,6 +6,11 @@ export const twentyUrlStorage = storage.defineItem<string>('sync:twentyUrl', {
   fallback: '',
 });
 
+// API key is a secret — keep it in local storage only, never synced across devices
+export const apiKeyStorage = storage.defineItem<string>('local:apiKey', {
+  fallback: '',
+});
+
 export const lastCapturedStorage = storage.defineItem<Array<{
   linkedinUrl: string;
   name: string;
@@ -18,13 +23,19 @@ export const lastCapturedStorage = storage.defineItem<Array<{
 
 // Helper functions
 export async function getSettings(): Promise<ExtensionSettings> {
-  const twentyUrl = await twentyUrlStorage.getValue();
-  return { twentyUrl };
+  const [twentyUrl, apiKey] = await Promise.all([
+    twentyUrlStorage.getValue(),
+    apiKeyStorage.getValue(),
+  ]);
+  return { twentyUrl, apiKey };
 }
 
 export async function saveSettings(settings: Partial<ExtensionSettings>): Promise<void> {
   if (settings.twentyUrl !== undefined) {
     await twentyUrlStorage.setValue(settings.twentyUrl);
+  }
+  if (settings.apiKey !== undefined) {
+    await apiKeyStorage.setValue(settings.apiKey);
   }
 }
 

--- a/utils/twenty-api.ts
+++ b/utils/twenty-api.ts
@@ -1,5 +1,4 @@
 import type {
-  TwentyTokenPair,
   GraphQLResponse,
   PeopleQueryResult,
   CompaniesQueryResult,
@@ -8,6 +7,7 @@ import type {
   LinkedInProfileData,
   LinkedInCompanyData,
 } from '../types';
+import { isCountryName, canonicalCountry } from './countries';
 
 // GraphQL Queries - Using correct Links composite field structure
 // Links type has: primaryLinkUrl, primaryLinkLabel, secondaryLinks
@@ -192,6 +192,8 @@ const CREATE_COMPANY = `
 export class TwentyApiClient {
   private baseUrl: string;
   private token: string | null = null;
+  // Cache of writable field names per input type (from GraphQL introspection)
+  private inputFieldsCache = new Map<string, Set<string>>();
 
   constructor(baseUrl: string) {
     this.baseUrl = baseUrl.replace(/\/$/, '');
@@ -199,100 +201,6 @@ export class TwentyApiClient {
 
   setToken(token: string) {
     this.token = token;
-  }
-
-  // Upload an image via GraphQL multipart upload
-  async uploadImageViaGraphQL(imageUrl: string, filename?: string): Promise<string | null> {
-    if (!this.token) {
-      console.error('[Twenty] No authentication token set for image upload');
-      return null;
-    }
-
-    console.log('[Twenty] Starting image upload from:', imageUrl);
-
-    try {
-      // Fetch the image
-      console.log('[Twenty] Fetching image...');
-      const response = await fetch(imageUrl);
-      if (!response.ok) {
-        console.error('[Twenty] Failed to fetch image:', response.status, response.statusText);
-        return null;
-      }
-
-      const blob = await response.blob();
-      console.log('[Twenty] Image fetched, size:', blob.size, 'type:', blob.type);
-      
-      const finalFilename = filename || `profile-${Date.now()}.jpg`;
-
-      // GraphQL multipart upload format (Apollo Upload spec)
-      // https://github.com/jaydenseric/graphql-multipart-request-spec
-      const operations = JSON.stringify({
-        query: `
-          mutation UploadImage($file: Upload!, $fileFolder: FileFolder) {
-            uploadImage(file: $file, fileFolder: $fileFolder) {
-              path
-              token
-            }
-          }
-        `,
-        variables: {
-          file: null,
-          fileFolder: 'PersonPicture',
-        },
-      });
-
-      const map = JSON.stringify({
-        '0': ['variables.file'],
-      });
-
-      const formData = new FormData();
-      formData.append('operations', operations);
-      formData.append('map', map);
-      formData.append('0', blob, finalFilename);
-
-      const uploadUrl = `${this.baseUrl}/graphql`;
-      console.log('[Twenty] Uploading via GraphQL to:', uploadUrl);
-      
-      const uploadResponse = await fetch(uploadUrl, {
-        method: 'POST',
-        headers: {
-          Authorization: `Bearer ${this.token}`,
-        },
-        body: formData,
-      });
-
-      console.log('[Twenty] Upload response status:', uploadResponse.status);
-
-      if (!uploadResponse.ok) {
-        const errorText = await uploadResponse.text();
-        console.error('[Twenty] Failed to upload image:', uploadResponse.status, errorText);
-        return null;
-      }
-
-      const result = await uploadResponse.json();
-      console.log('[Twenty] Upload result:', result);
-      
-      if (result.errors?.length) {
-        console.error('[Twenty] GraphQL errors:', result.errors);
-        return null;
-      }
-
-      // Return just the path - Twenty stores paths, not full URLs with tokens
-      // The server will handle authentication when serving the image
-      const uploadData = result.data?.uploadImage;
-      if (uploadData?.path) {
-        // Store just the path - Twenty's frontend will request with fresh tokens
-        const avatarPath = uploadData.path;
-        console.log('[Twenty] Image uploaded successfully, path:', avatarPath);
-        return avatarPath;
-      }
-
-      console.warn('[Twenty] Upload succeeded but no path/token in response:', result);
-      return null;
-    } catch (error) {
-      console.error('[Twenty] Error uploading image:', error);
-      return null;
-    }
   }
 
   private async graphqlRequest<T>(
@@ -309,6 +217,9 @@ export class TwentyApiClient {
         'Content-Type': 'application/json',
         Authorization: `Bearer ${this.token}`,
       },
+      // Send cookies too, so deployments behind an authenticating reverse proxy
+      // still pass the gateway. Harmless when no such proxy is present.
+      credentials: 'include',
       body: JSON.stringify({ query, variables }),
     });
 
@@ -317,6 +228,75 @@ export class TwentyApiClient {
     }
 
     return response.json();
+  }
+
+  // Run a mutation whose variables contain an input object, and self-heal against
+  // schema drift: if Twenty rejects an input field it no longer has (e.g. a
+  // renamed/removed standard field), drop that field and retry. This keeps the
+  // extension working across Twenty releases without code changes.
+  private async graphqlMutate<T>(
+    query: string,
+    variables: Record<string, unknown>,
+    inputKey = 'input'
+  ): Promise<GraphQLResponse<T>> {
+    // Clone so we can safely prune fields between attempts
+    const vars = { ...variables, [inputKey]: { ...(variables[inputKey] as Record<string, unknown>) } };
+    const input = vars[inputKey] as Record<string, unknown>;
+
+    let result = await this.graphqlRequest<T>(query, vars);
+    let guard = 0;
+    while (guard++ < 8) {
+      const message = result.errors?.[0]?.message || '';
+      const match = message.match(/doesn'?t have any ["“]([^"”]+)["”] field/i);
+      if (!match || !(match[1] in input)) break;
+      console.warn(`[Twenty] Schema has no "${match[1]}" field — dropping it and retrying`);
+      delete input[match[1]];
+      result = await this.graphqlRequest<T>(query, vars);
+    }
+    return result;
+  }
+
+  // Introspect the writable field names of a GraphQL input type (cached).
+  private async getInputFields(typeName: string): Promise<Set<string>> {
+    const cached = this.inputFieldsCache.get(typeName);
+    if (cached) return cached;
+    let names = new Set<string>();
+    try {
+      const result = await this.graphqlRequest<{ __type: { inputFields: { name: string }[] | null } | null }>(
+        `query InputFields($n: String!) { __type(name: $n) { inputFields { name } } }`,
+        { n: typeName }
+      );
+      names = new Set((result.data?.__type?.inputFields || []).map((f) => f.name));
+    } catch (error) {
+      console.warn(`[Twenty] Could not introspect ${typeName}:`, error);
+    }
+    this.inputFieldsCache.set(typeName, names);
+    return names;
+  }
+
+  // Resolve where a location string should go on the given input type, and shape
+  // the value accordingly. Twenty has changed this over time, so we discover it:
+  // a scalar field (city/location/town) takes the raw string; an ADDRESS composite
+  // (e.g. a custom "address" field) takes parsed city/country subfields.
+  private async buildLocationInput(
+    typeName: string,
+    location: string
+  ): Promise<{ field: string; value: unknown } | null> {
+    const fields = await this.getInputFields(typeName);
+
+    const scalar = ['city', 'location', 'town'].find((f) => fields.has(f));
+    if (scalar) return { field: scalar, value: location };
+
+    // Otherwise look for an ADDRESS composite field (standard or custom),
+    // matching any field whose name looks address-like.
+    const addressField =
+      (fields.has('address') ? 'address' : null) ||
+      Array.from(fields).find((f) => /address/i.test(f));
+    if (addressField) return { field: addressField, value: parseLocationToAddress(location) };
+
+    if (fields.size === 0) return { field: 'city', value: location }; // introspection off; optimistic
+    console.warn(`[Twenty] No location/address field on ${typeName}. Available:`, Array.from(fields));
+    return null;
   }
 
   async findPersonByLinkedInUrl(
@@ -472,13 +452,9 @@ export class TwentyApiClient {
   private async createCompanySimple(
     name: string
   ): Promise<CreateCompanyResult['createCompany']> {
-    const result = await this.graphqlRequest<CreateCompanyResult>(
+    const result = await this.graphqlMutate<CreateCompanyResult>(
       CREATE_COMPANY,
-      {
-        input: {
-          name,
-        },
-      }
+      { input: { name } }
     );
 
     if (result.errors?.length) {
@@ -515,43 +491,31 @@ export class TwentyApiClient {
       console.log('[Twenty] No currentCompany in data, skipping company creation');
     }
 
-    // Try to upload profile image to Twenty storage
-    let avatarUrl = data.profileImageUrl || '';
-    if (data.profileImageUrl) {
-      console.log('[Twenty] Attempting to upload profile image...');
-      try {
-        const uploadedUrl = await this.uploadImageViaGraphQL(
-          data.profileImageUrl,
-          `${data.firstName}-${data.lastName}-profile.jpg`
-        );
-        if (uploadedUrl) {
-          avatarUrl = uploadedUrl;
-          console.log('[Twenty] Profile image uploaded, using:', avatarUrl);
-        } else {
-          console.log('[Twenty] Upload failed, using LinkedIn URL directly');
-        }
-      } catch (error) {
-        console.error('[Twenty] Error uploading profile image:', error);
-      }
-    }
+    // Link the LinkedIn photo URL directly. Twenty's old multipart uploadImage
+    // mutation no longer exists, and Person exposes an avatarUrl field.
+    const avatarUrl = data.profileImageUrl || '';
 
-    const result = await this.graphqlRequest<CreatePersonResult>(CREATE_PERSON, {
-      input: {
-        name: {
-          firstName: data.firstName,
-          lastName: data.lastName,
-        },
-        linkedinLink: {
-          primaryLinkUrl: data.linkedinUrl,
-          primaryLinkLabel: 'LinkedIn',
-        },
-        jobTitle: data.headline || '',
-        avatarUrl: avatarUrl,
-        city: data.location || '',
-        // Link to company if we found/created one
-        companyId: companyId,
+    // Only include optional fields that actually have a value — sending empty
+    // strings makes Twenty validate fields the page never filled in.
+    const input: Record<string, unknown> = {
+      name: {
+        firstName: data.firstName,
+        lastName: data.lastName,
       },
-    });
+      linkedinLink: {
+        primaryLinkUrl: data.linkedinUrl,
+        primaryLinkLabel: 'LinkedIn',
+      },
+    };
+    if (data.headline) input.jobTitle = data.headline;
+    if (avatarUrl) input.avatarUrl = avatarUrl;
+    if (data.location) {
+      const loc = await this.buildLocationInput('PersonCreateInput', data.location);
+      if (loc) input[loc.field] = loc.value;
+    }
+    if (companyId) input.companyId = companyId;
+
+    const result = await this.graphqlMutate<CreatePersonResult>(CREATE_PERSON, { input });
 
     if (result.errors?.length) {
       throw new Error(result.errors[0].message);
@@ -567,27 +531,22 @@ export class TwentyApiClient {
   async createCompany(
     data: LinkedInCompanyData
   ): Promise<CreateCompanyResult['createCompany']> {
-    const result = await this.graphqlRequest<CreateCompanyResult>(
-      CREATE_COMPANY,
-      {
-        input: {
-          name: data.name,
-          linkedinLink: {
-            primaryLinkUrl: data.linkedinUrl,
-            primaryLinkLabel: 'LinkedIn',
-          },
-          domainName: data.website
-            ? {
-                primaryLinkUrl: data.website,
-                primaryLinkLabel: 'Website',
-              }
-            : undefined,
-          employees: data.employeeCount
-            ? this.parseEmployeeCount(data.employeeCount)
-            : undefined,
-        },
-      }
-    );
+    const input: Record<string, unknown> = {
+      name: data.name,
+      linkedinLink: {
+        primaryLinkUrl: data.linkedinUrl,
+        primaryLinkLabel: 'LinkedIn',
+      },
+    };
+    if (data.website) {
+      input.domainName = { primaryLinkUrl: data.website, primaryLinkLabel: 'Website' };
+    }
+    if (data.employeeCount) {
+      const employees = this.parseEmployeeCount(data.employeeCount);
+      if (employees !== undefined) input.employees = employees;
+    }
+
+    const result = await this.graphqlMutate<CreateCompanyResult>(CREATE_COMPANY, { input });
 
     if (result.errors?.length) {
       throw new Error(result.errors[0].message);
@@ -602,11 +561,13 @@ export class TwentyApiClient {
 
   async testConnection(): Promise<boolean> {
     try {
-      // Simple query to test if the connection works
-      const result = await this.graphqlRequest<{ currentWorkspace: { id: string } }>(
-        `query { currentWorkspace { id } }`
+      // Probe a field the API-key (Core API) schema actually exposes. The
+      // frontend-only `currentWorkspace`/`currentUser` roots are not available
+      // here, but `people` is — and it's what the rest of the extension uses.
+      const result = await this.graphqlRequest<PeopleQueryResult>(
+        `query TestConnection { people(first: 1) { edges { node { id } } } }`
       );
-      return !result.errors?.length && !!result.data?.currentWorkspace;
+      return !result.errors?.length && Array.isArray(result.data?.people?.edges);
     } catch {
       return false;
     }
@@ -677,42 +638,30 @@ export class TwentyApiClient {
         }
       }
 
-      // Try to upload profile image to Twenty storage
-      let avatarUrl = personData.profileImageUrl || undefined;
-      if (personData.profileImageUrl) {
-        try {
-          const uploadedUrl = await this.uploadImageViaGraphQL(
-            personData.profileImageUrl,
-            `${personData.firstName}-${personData.lastName}-profile.jpg`
-          );
-          if (uploadedUrl) {
-            avatarUrl = uploadedUrl;
-            console.log('[Twenty] Profile image uploaded for update:', avatarUrl);
-          }
-        } catch (error) {
-          console.error('[Twenty] Error uploading profile image:', error);
-        }
-      }
+      // Link the LinkedIn photo URL directly (see createPerson).
+      const avatarUrl = personData.profileImageUrl || undefined;
 
-      const result = await this.graphqlRequest<{ updatePerson: { id: string } }>(
+      const input: Record<string, unknown> = {
+        name: {
+          firstName: personData.firstName,
+          lastName: personData.lastName,
+        },
+        linkedinLink: {
+          primaryLinkUrl: personData.linkedinUrl,
+          primaryLinkLabel: 'LinkedIn',
+        },
+      };
+      if (personData.headline) input.jobTitle = personData.headline;
+      if (avatarUrl) input.avatarUrl = avatarUrl;
+      if (personData.location) {
+        const loc = await this.buildLocationInput('PersonUpdateInput', personData.location);
+        if (loc) input[loc.field] = loc.value;
+      }
+      if (companyId) input.companyId = companyId;
+
+      const result = await this.graphqlMutate<{ updatePerson: { id: string } }>(
         UPDATE_PERSON,
-        {
-          id,
-          input: {
-            name: {
-              firstName: personData.firstName,
-              lastName: personData.lastName,
-            },
-            linkedinLink: {
-              primaryLinkUrl: personData.linkedinUrl,
-              primaryLinkLabel: 'LinkedIn',
-            },
-            jobTitle: personData.headline || undefined,
-            avatarUrl: avatarUrl,
-            city: personData.location || undefined,
-            companyId: companyId,
-          },
-        }
+        { id, input }
       );
 
       if (result.errors?.length) {
@@ -721,27 +670,24 @@ export class TwentyApiClient {
     } else if (type === 'company' && data.type === 'company') {
       const companyData = data as LinkedInCompanyData;
 
-      const result = await this.graphqlRequest<{ updateCompany: { id: string } }>(
+      const input: Record<string, unknown> = {
+        name: companyData.name,
+        linkedinLink: {
+          primaryLinkUrl: companyData.linkedinUrl,
+          primaryLinkLabel: 'LinkedIn',
+        },
+      };
+      if (companyData.website) {
+        input.domainName = { primaryLinkUrl: companyData.website, primaryLinkLabel: 'Website' };
+      }
+      if (companyData.employeeCount) {
+        const employees = this.parseEmployeeCount(companyData.employeeCount);
+        if (employees !== undefined) input.employees = employees;
+      }
+
+      const result = await this.graphqlMutate<{ updateCompany: { id: string } }>(
         UPDATE_COMPANY,
-        {
-          id,
-          input: {
-            name: companyData.name,
-            linkedinLink: {
-              primaryLinkUrl: companyData.linkedinUrl,
-              primaryLinkLabel: 'LinkedIn',
-            },
-            domainName: companyData.website
-              ? {
-                  primaryLinkUrl: companyData.website,
-                  primaryLinkLabel: 'Website',
-                }
-              : undefined,
-            employees: companyData.employeeCount
-              ? this.parseEmployeeCount(companyData.employeeCount)
-              : undefined,
-          },
-        }
+        { id, input }
       );
 
       if (result.errors?.length) {
@@ -766,14 +712,24 @@ export class TwentyApiClient {
   }
 }
 
-// Helper to extract token from Twenty's tokenPair cookie
-export function extractTokenFromCookie(
-  cookieValue: string
-): string | null {
-  try {
-    const tokenPair: TwentyTokenPair = JSON.parse(cookieValue);
-    return tokenPair.accessOrWorkspaceAgnosticToken?.token || null;
-  } catch {
-    return null;
+// Split a LinkedIn location string ("City, Region, Country") into Twenty ADDRESS
+// composite subfields. LinkedIn always puts the city first, so we take that
+// directly (no city list needed); the last segment is set as country only when
+// it matches a known country name. A lone token is classified as country if it's
+// a known country, otherwise treated as the city.
+function parseLocationToAddress(location: string): Record<string, string> {
+  const parts = location.split(',').map((s) => s.trim()).filter(Boolean);
+  const out: Record<string, string> = {};
+  if (parts.length === 0) return out;
+
+  if (parts.length === 1) {
+    if (isCountryName(parts[0])) out.addressCountry = canonicalCountry(parts[0]);
+    else out.addressCity = parts[0];
+    return out;
   }
+
+  out.addressCity = parts[0];
+  const last = parts[parts.length - 1];
+  if (isCountryName(last)) out.addressCountry = canonicalCountry(last);
+  return out;
 }

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -6,8 +6,8 @@ export default defineConfig({
   manifest: {
     name: 'Twenty CRM - LinkedIn Capture',
     description: 'Capture LinkedIn profiles and companies to your Twenty CRM',
-    version: '1.0.0',
-    permissions: ['storage', 'cookies', 'activeTab'],
+    version: '1.1.0',
+    permissions: ['storage', 'activeTab'],
     host_permissions: ['*://*.linkedin.com/*', '*://*/*'],
     icons: {
       16: '/icon/16.png',


### PR DESCRIPTION
Redesign authentication to use a Twenty API key stored in local extension storage instead of relying on session cookies. Remove the `cookies` permission and the `TwentyTokenPair` type. Update the popup UI to accept an API key.

Refactor LinkedIn scraping to use structural DOM anchors (stable `h1`, `a[href*="contact-info"]`, company entity button) instead of fragile class-name selectors. Add country detection utility for location parsing.

Improve the build pipeline to type-check before packaging, produce both Chrome and Firefox ZIPs, and upload all artifacts under a single name. Update dependencies (TypeScript 6, WXT 0.20.27, Vue 3.5.38). Bump extension version to 1.1.0.